### PR TITLE
Fix Doxygen comments and translate build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# При генерации Code::Blocks проекта с MinGW можно использовать так:
+# When generating a Code::Blocks project with MinGW, you can use:
 # cmake -G "CodeBlocks - MinGW Makefiles" -S . -B build-cb
 cmake_minimum_required(VERSION 3.18)
 project(time_shield LANGUAGES CXX)
@@ -16,32 +16,32 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Абсолютный путь к корню проекта (где CMakeLists.txt)
+# Absolute path to the project root (where CMakeLists.txt resides)
 get_filename_component(PROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 
-# Добавляем макрос LOGIT_BASE_PATH
+# Define the LOGIT_BASE_PATH macro
 add_compile_definitions(LOGIT_BASE_PATH="${PROJECT_ROOT}")
 
-# Пути к инклудам и библиотекам
+# Include and library paths
 set(PROJECT_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/logit_cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/fmt/include
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/time-shield-cpp/include/time_shield_cpp
 )
 
-# Заголовочные файлы из include/
+# Header files from include/
 file(GLOB_RECURSE PROJECT_HEADERS
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     include/*.hpp
 )
 
-# Создаём виртуальную цель для заголовков, чтобы отображались в IDE
+# Create a virtual target for headers so IDEs show them
 add_custom_target(project_headers SOURCES ${PROJECT_HEADERS})
 
-# Находим все .cpp файлы в examples/
+# Locate all .cpp files in examples/
 file(GLOB EXAMPLES_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} examples/*.cpp)
 
-# Для каждого создаём отдельную цель
+# Create a separate target for each example
 foreach(example_src ${EXAMPLES_SOURCES})
     get_filename_component(example_name ${example_src} NAME_WE)
 
@@ -57,7 +57,7 @@ foreach(example_src ${EXAMPLES_SOURCES})
     target_compile_definitions(${example_name} PRIVATE ${PROJECT_DEFINES})
     target_link_libraries(${example_name} PRIVATE ${PROJECT_LIBS})
 
-    # Добавляем заголовки как SOURCES (чтобы IDE показывала их)
+    # Add headers as SOURCES so IDEs display them
     set_source_files_properties(${PROJECT_HEADERS} PROPERTIES HEADER_FILE_ONLY ON)
     target_sources(${example_name} PRIVATE ${PROJECT_HEADERS})
     

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -256,7 +256,7 @@ Example:
 
 `LogIt++` provides shortened versions of logging macros when `LOGIT_SHORT_NAME` is defined. These macros allow for concise logging across different log levels, including both standard and stream-based logging.
 
-### Available TRACE-level macros:
+## Available TRACE-level macros:
   - **Basic logging**:
 
 	- `LOG_T(...)`: Logs a TRACE-level message.
@@ -296,9 +296,7 @@ Example:
 	
 These macros provide flexibility and convenience when logging messages at the TRACE level. They allow you to choose between different logging styles, such as standard logging, formatted logging, and printing each argument separately.
 
-#### Note: 
-
-Similar macros are available for other log levels — **INFO** (`LOG_I`, `LOG_INFO`), **DEBUG** (`LOG_D`, `LOG_DEBUG`), **WARN** (`LOG_W`, `LOG_WARN`), **ERROR** (`LOG_E`, `LOG_ERROR`), and **FATAL** (`LOG_F`, `LOG_FATAL`). The naming conventions are consistent across levels, you only need to replace the level letter or word in the macro name.
+**Note:** Similar macros are available for other log levels — **INFO** (`LOG_I`, `LOG_INFO`), **DEBUG** (`LOG_D`, `LOG_DEBUG`), **WARN** (`LOG_W`, `LOG_WARN`), **ERROR** (`LOG_E`, `LOG_ERROR`), and **FATAL** (`LOG_F`, `LOG_FATAL`). The naming conventions are consistent across levels; replace the level letter or word in the macro name.
 
 \code{.cpp} 
 LOG_T("Trace message using short macro"); 

--- a/examples/example_logit_basic.cpp
+++ b/examples/example_logit_basic.cpp
@@ -1,4 +1,4 @@
-/// \file logging_example.cpp
+/// \file example_logit_basic.cpp
 /// \brief Demonstrates the usage of the LogIt library with various data types and scenarios.
 
 // #define LOGIT_BASE_PATH "E:\\_repoz\\log-it-cpp"  <- set via CMake

--- a/include/logit_cpp/logit/enums.hpp
+++ b/include/logit_cpp/logit/enums.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #ifndef _LOGIT_ENUMS_HPP_INCLUDED
 #define _LOGIT_ENUMS_HPP_INCLUDED
-/// \file Enums.hpp
+/// \file enums.hpp
 /// \brief Enumerations and utility functions for logging levels and text colors.
 
 #include <array>

--- a/include/logit_cpp/logit/formatter/compiler/PatternCompiler.hpp
+++ b/include/logit_cpp/logit/formatter/compiler/PatternCompiler.hpp
@@ -59,7 +59,7 @@ namespace logit {
             // File and Function
             FileName,               ///< %f, %fn, %bs: Basename of the source file
             FullFileName,           ///< %g, %ffn: Full file path
-            SourceFileAndLine,      ///< %@: Source file and line number
+            SourceFileAndLine,      ///< %\@: Source file and line number
             LineNumber,             ///< %#: Line number
             FunctionName,           ///< %!: Function name
 

--- a/include/logit_cpp/logit/loggers/ILogger.hpp
+++ b/include/logit_cpp/logit/loggers/ILogger.hpp
@@ -34,7 +34,7 @@ namespace logit {
         ///
         /// \param record The log record containing details about the log event.
         /// \param message The formatted log message.
-        virtual void log(const LogRecord&, const std::string&) = 0;
+        virtual void log(const LogRecord& record, const std::string& message) = 0;
 
         /// \brief Retrieves a string parameter from the logger.
         /// Derived classes should implement this to return specific string-based parameters.


### PR DESCRIPTION
## Summary
- fix incorrect Doxygen file names and parameter docs
- translate Russian comments in CMakeLists.txt
- tweak headings in documentation

## Testing
- `doxygen Doxyfile`
- `cmake --build .` *(fails: now_realtime_us() only supported on Windows)*

------
https://chatgpt.com/codex/tasks/task_e_68794a3196ac832cbf26cbed9bceaa9c