### PR TITLE
Add log level control

### DIFF
--- a/include/logit_cpp/logit/LogMacros.hpp
+++ b/include/logit_cpp/logit/LogMacros.hpp
@@ -971,6 +971,17 @@
 #define LOGIT_SET_TIME_OFFSET(logger_index, offset_ms) \
     logit::Logger::get_instance().set_timestamp_offset(logger_index, offset_ms)
 
+/// \brief Sets minimal log level for a specific logger.
+/// \param logger_index Index of logger.
+/// \param level Minimum log level.
+#define LOGIT_SET_LOG_LEVEL_TO(logger_index, level) \
+    logit::Logger::get_instance().set_log_level(logger_index, level)
+
+/// \brief Sets minimal log level for all loggers.
+/// \param level Minimum log level.
+#define LOGIT_SET_LOG_LEVEL(level) \
+    logit::Logger::get_instance().set_log_level(level)
+
 /// \brief Checks if a logger is in single mode.
 /// \param logger_index Index of logger.
 /// \return True if in single mode, false otherwise.

--- a/include/logit_cpp/logit/loggers/ConsoleLogger.hpp
+++ b/include/logit_cpp/logit/loggers/ConsoleLogger.hpp
@@ -161,6 +161,16 @@ namespace logit {
             return 0.0;
         }
 
+        /// \brief Sets the minimal log level for this logger.
+        void set_log_level(LogLevel level) override {
+            m_log_level = static_cast<int>(level);
+        }
+
+        /// \brief Gets the minimal log level for this logger.
+        LogLevel get_log_level() const override {
+            return static_cast<LogLevel>(m_log_level.load());
+        }
+
         /// \brief Waits for all asynchronous tasks to complete.
         /// If asynchronous logging is enabled, waits for all pending log messages to be written.
         void wait() override {
@@ -179,6 +189,7 @@ namespace logit {
         mutable std::mutex m_mutex;     ///< Mutex to protect console output
         Config             m_config;    ///< Configuration for the console logger.
         std::atomic<int64_t> m_last_log_ts = ATOMIC_VAR_INIT(0);
+        std::atomic<int>    m_log_level = ATOMIC_VAR_INIT(static_cast<int>(LogLevel::LOG_LVL_TRACE));
 
 #       if defined(_WIN32)
 

--- a/include/logit_cpp/logit/loggers/ILogger.hpp
+++ b/include/logit_cpp/logit/loggers/ILogger.hpp
@@ -21,6 +21,7 @@
 
 namespace logit {
 
+
     /// \interface ILogger
     /// \brief Interface for loggers that handle log message output.
     class ILogger {
@@ -53,6 +54,14 @@ namespace logit {
         /// \param param The parameter type to retrieve.
         /// \return A double representing the requested parameter.
         virtual double get_float_param(const LoggerParam& param) const = 0;
+
+        /// \brief Sets the minimal log level for this logger.
+        /// \param level Minimum log level.
+        virtual void set_log_level(LogLevel level) = 0;
+
+        /// \brief Gets the minimal log level for this logger.
+        /// \return Current minimal log level.
+        virtual LogLevel get_log_level() const = 0;
 
         /// \brief Waits for all asynchronous logging operations to complete.
         ///

--- a/include/logit_cpp/logit/loggers/UniqueFileLogger.hpp
+++ b/include/logit_cpp/logit/loggers/UniqueFileLogger.hpp
@@ -40,10 +40,13 @@ namespace logit {
         std::string get_string_param(const LoggerParam&) const override { return {}; }
         int64_t get_int_param(const LoggerParam&) const override { return 0; }
         double get_float_param(const LoggerParam&) const override { return 0.0; }
+        void set_log_level(LogLevel) override {}
+        LogLevel get_log_level() const override { return LogLevel::LOG_LVL_TRACE; }
         void wait() override {}
 
     private:
         void warn() const { std::cerr << "UniqueFileLogger is not supported under Emscripten" << std::endl; }
+        std::atomic<int> m_log_level = ATOMIC_VAR_INIT(static_cast<int>(LogLevel::LOG_LVL_TRACE));
     };
 
 #else
@@ -236,6 +239,16 @@ namespace logit {
             return 0.0;
         }
 
+        /// \brief Sets the minimal log level for this logger.
+        void set_log_level(LogLevel level) override {
+            m_log_level = static_cast<int>(level);
+        }
+
+        /// \brief Gets the minimal log level for this logger.
+        LogLevel get_log_level() const override {
+            return static_cast<LogLevel>(m_log_level.load());
+        }
+
         /// \brief Waits for all asynchronous tasks to complete.
         void wait() override {
             if (!m_config.async) return;
@@ -268,6 +281,7 @@ namespace logit {
         std::unordered_map<std::thread::id, ThreadLogInfo> m_thread_log_info; ///< Map to store log information per thread.
 
         std::atomic<int64_t> m_last_log_ts = ATOMIC_VAR_INIT(0); ///< Timestamp of the last log.
+        std::atomic<int>    m_log_level = ATOMIC_VAR_INIT(static_cast<int>(LogLevel::LOG_LVL_TRACE));
 
 
         /// \brief Starts the logging process by initializing the directory and removing old logs.


### PR DESCRIPTION
## Summary
- introduce log level setters in `ILogger`
- implement log level handling for all loggers
- support log level filtering in `Logger`
- add macros to manage log levels
- drop redundant includes for loggers

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: time_shield headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a297dc740832c98088ba1cbc0796d