### PR TITLE
Fix utils header guard typo

### DIFF
--- a/include/logit_cpp/logit/utils.hpp
+++ b/include/logit_cpp/logit/utils.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef _LOGIT_UITLS_HPP_INCLUDED
-#define _LOGIT_UITLS_HPP_INCLUDED
+#ifndef _LOGIT_UTILS_HPP_INCLUDED
+#define _LOGIT_UTILS_HPP_INCLUDED
 
 /// \file utils.hpp
 /// \brief Aggregates various utility modules used throughout the project.
@@ -16,4 +16,4 @@
 #include "utils/path_utils.hpp"
 #include "utils/LogRecord.hpp"
 
-#endif // _LOGIT_UITLS_HPP_INCLUDED
+#endif // _LOGIT_UTILS_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- Correct spelling in `utils.hpp` header guard

## Testing
- `cmake -S . -B build` *(fails: TimeShield not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f572df4c832cb8d6e3fa034cfa86