### PR TITLE
Ensure LogRecord uses proper entry headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+## Header inclusion
+This project provides dedicated entry-point headers that include internal dependencies in the correct order. Use these headers instead of forward-declaring library types.
+
+* `include/logit_cpp/LogIt.hpp` – main entry for the entire library.
+* `include/logit_cpp/logit/utils.hpp` – aggregates the utilities module.
+
+Including through these headers ensures dependencies are resolved without manual forward declarations.

--- a/include/logit_cpp/logit/utils.hpp
+++ b/include/logit_cpp/logit/utils.hpp
@@ -9,7 +9,6 @@
 /// encoding utilities, path utilities, and log record management. Including this header
 /// provides a single point of access to common utility functions and types.
 
-#include "LogItConfig.hpp"
 #include "enums.hpp"
 #include "utils/format.hpp"
 #include "utils/VariableValue.hpp"

--- a/include/logit_cpp/logit/utils.hpp
+++ b/include/logit_cpp/logit/utils.hpp
@@ -9,6 +9,8 @@
 /// encoding utilities, path utilities, and log record management. Including this header
 /// provides a single point of access to common utility functions and types.
 
+#include "LogItConfig.hpp"
+#include "enums.hpp"
 #include "utils/format.hpp"
 #include "utils/VariableValue.hpp"
 #include "utils/argument_utils.hpp"

--- a/include/logit_cpp/logit/utils/LogRecord.hpp
+++ b/include/logit_cpp/logit/utils/LogRecord.hpp
@@ -5,7 +5,11 @@
 /// \file LogRecord.hpp
 /// \brief Contains the definition of the LogRecord structure for storing log data.
 
+#include <string>
+#include <vector>
+#include <cstdint>
 #include <thread>
+#include "logit/enums.hpp"
 
 namespace logit {
 

--- a/include/logit_cpp/logit/utils/LogRecord.hpp
+++ b/include/logit_cpp/logit/utils/LogRecord.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <cstdint>
 #include <thread>
-#include "logit/enums.hpp"
 
 namespace logit {
 


### PR DESCRIPTION
## Summary
- drop unnecessary VariableValue and LogItConfig includes and leftover format declaration from LogRecord
- pull LogItConfig and enums into utils.hpp so the utilities entry point exposes log levels

## Testing
- `g++ -std=c++17 -Iinclude/logit_cpp -I/tmp/stubs -c include/logit_cpp/logit/utils.hpp -o /tmp/utils.o`


------
https://chatgpt.com/codex/tasks/task_e_68c4f5594f80832cab5283814041fd2a