### PR TITLE
Make encoding utils header lean

### DIFF
--- a/include/logit_cpp/logit/utils/encoding_utils.hpp
+++ b/include/logit_cpp/logit/utils/encoding_utils.hpp
@@ -1,23 +1,30 @@
+#pragma once
+
 #ifndef _LOGIT_ENCODING_UTILS_HPP_INCLUDED
 #define _LOGIT_ENCODING_UTILS_HPP_INCLUDED
 
 /// \file encoding_utils.hpp
 /// \brief Utilities for working with character encodings and string transformations.
 
+#include <string>
+
 #if defined(_WIN32)
-#include <windows.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <stringapiset.h>
 
 namespace logit {
 
     /// \brief Converts a UTF-8 string to an ANSI string (Windows-specific).
     /// \param utf8 The UTF-8 encoded string.
     /// \return The converted ANSI string.
-    std::string utf8_to_ansi(const std::string& utf8) {
+    inline std::string utf8_to_ansi(const std::string& utf8) {
         int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
         if (n_len == 0) return {};
 
         std::wstring wide_string(n_len + 1, L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1,  &wide_string[0], n_len);
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &wide_string[0], n_len);
 
         n_len = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
         if (n_len == 0) return {};
@@ -27,7 +34,7 @@ namespace logit {
         return ansi_string;
     }
 
-};
-#endif
+} // namespace logit
+#endif // defined(_WIN32)
 
 #endif // _LOGIT_ENCODING_UTILS_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- retain `_LOGIT_ENCODING_UTILS_HPP_INCLUDED` guard alongside `#pragma once`
- switch to `<stringapiset.h>` and drop `<windows.h>`, defining only `NOMINMAX`
- keep `utf8_to_ansi` inline for header-only use

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c4f54f08b4832c84dc0186ee29b982