### PR TITLE
refactor(utils): modernize path conversions and errors

### DIFF
--- a/include/logit_cpp/logit/utils/encoding_utils.hpp
+++ b/include/logit_cpp/logit/utils/encoding_utils.hpp
@@ -34,6 +34,28 @@ namespace logit {
         return ansi_string;
     }
 
+    /// \brief Converts a UTF-8 string to a wide UTF-16 string (Windows-specific).
+    /// \param utf8 The UTF-8 encoded string.
+    /// \return The converted wide string.
+    inline std::wstring utf8_to_wstring(const std::string& utf8) {
+        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
+        if (n_len == 0) return {};
+        std::wstring wide_string(n_len - 1, L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &wide_string[0], n_len);
+        return wide_string;
+    }
+
+    /// \brief Converts a wide UTF-16 string to a UTF-8 string (Windows-specific).
+    /// \param wide The UTF-16 encoded string.
+    /// \return The converted UTF-8 string.
+    inline std::string wstring_to_utf8(const std::wstring& wide) {
+        int n_len = WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, NULL, 0, NULL, NULL);
+        if (n_len == 0) return {};
+        std::string utf8(n_len - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), -1, &utf8[0], n_len, NULL, NULL);
+        return utf8;
+    }
+
 } // namespace logit
 #endif // defined(_WIN32)
 

--- a/include/logit_cpp/logit/utils/path_utils.hpp
+++ b/include/logit_cpp/logit/utils/path_utils.hpp
@@ -13,12 +13,12 @@
 #include <stdexcept>
 #endif
 
+#include "encoding_utils.hpp"
+
 #ifdef _WIN32
 // For Windows systems
 #include <direct.h>
 #include <windows.h>
-#include <locale>
-#include <codecvt>
 #elif defined(__APPLE__)
 // For macOS systems
 #include <mach-o/dyld.h>
@@ -46,10 +46,7 @@ namespace logit {
 
     inline std::string get_exec_dir() { return "./"; }
 
-    inline std::vector<std::string> get_list_files(const std::string&) {
-        std::cerr << "get_list_files is not supported under Emscripten" << std::endl;
-        return {};
-    }
+    inline std::vector<std::string> get_list_files(const std::string&) = delete;
 
     inline std::string get_file_name(const std::string& file_path) {
         size_t pos = file_path.find_last_of("/\\");
@@ -61,9 +58,7 @@ namespace logit {
         return file_path;
     }
 
-    inline void create_directories(const std::string&) {
-        std::cerr << "create_directories is not supported under Emscripten" << std::endl;
-    }
+    inline void create_directories(const std::string&) = delete;
 
     inline bool is_file(const std::string& path) {
         size_t dot_pos = path.find_last_of('.');
@@ -102,8 +97,7 @@ namespace logit {
         }
 
         // Convert from std::wstring (UTF-16) to std::string (UTF-8)
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        return converter.to_bytes(exe_path);
+        return wstring_to_utf8(exe_path);
 #       elif defined(__APPLE__)
         uint32_t size = 0;
         _NSGetExecutablePath(nullptr, &size);
@@ -149,7 +143,6 @@ namespace logit {
         std::vector<std::string> list_files;
 #       ifdef _WIN32
         // Use wide versions of functions to correctly handle non-ASCII characters.
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         std::wstring wsearch_path;
 
         // If the path is empty, use the current directory.
@@ -158,7 +151,7 @@ namespace logit {
             GetCurrentDirectoryW(MAX_PATH, buffer);
             wsearch_path = buffer;
         } else {
-            wsearch_path = converter.from_bytes(path);
+            wsearch_path = utf8_to_wstring(path);
         }
 
         // Ensure there is a trailing separator.
@@ -182,11 +175,11 @@ namespace logit {
 
                 if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
                     // Recursively process subdirectories.
-                    std::vector<std::string> sub_files = get_list_files(converter.to_bytes(wfull_path));
+                    std::vector<std::string> sub_files = get_list_files(wstring_to_utf8(wfull_path));
                     list_files.insert(list_files.end(), sub_files.begin(), sub_files.end());
                 } else {
                     // Add the found file.
-                    list_files.push_back(converter.to_bytes(wfull_path));
+                    list_files.push_back(wstring_to_utf8(wfull_path));
                 }
             } while (FindNextFileW(hFind, &fd));
             FindClose(hFind);
@@ -267,8 +260,7 @@ namespace logit {
     void create_directories(const std::string& path) {
 #       ifdef _WIN32
         // Convert UTF-8 string to wide string for Windows
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        std::wstring wide_path = converter.from_bytes(path);
+        std::wstring wide_path = utf8_to_wstring(path);
         std::filesystem::path dir(wide_path);
 #       else
         std::filesystem::path dir = std::filesystem::u8path(path);


### PR DESCRIPTION
## Summary
- remove Emscripten path utilities that only warned at runtime
- use Windows API for UTF-8/UTF-16 conversion instead of deprecated wstring_convert

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c504097128832c99ce5115acb6033d