### PR TITLE
fix(macros): remove internal semicolons from wait and shutdown

### DIFF
--- a/include/logit_cpp/logit/LogMacros.hpp
+++ b/include/logit_cpp/logit/LogMacros.hpp
@@ -960,10 +960,10 @@
 /// \}
 
 /// \brief Macro for waiting for all asynchronous loggers to finish processing.
-#define LOGIT_WAIT() logit::Logger::get_instance().wait();
+#define LOGIT_WAIT() logit::Logger::get_instance().wait()
 
 /// \brief Macro for shutting down logger system.
-#define LOGIT_SHUTDOWN() logit::Logger::get_instance().shutdown();
+#define LOGIT_SHUTDOWN() logit::Logger::get_instance().shutdown()
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- remove trailing semicolons inside `LOGIT_WAIT` and `LOGIT_SHUTDOWN` macros
- confirm examples invoke `LOGIT_WAIT` and `LOGIT_SHUTDOWN` with a trailing semicolon

## Testing
- `cmake -S . -B build -DLOG_IT_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c50fea4ce4832c850152c573129789