### PR TITLE
feat: include chrono in TaskExecutor header

### DIFF
--- a/include/logit_cpp/logit/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/TaskExecutor.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <condition_variable>
 #include <iostream>
+#include <chrono>
 
 namespace logit {
 


### PR DESCRIPTION
## Summary
- include chrono in TaskExecutor to support std::chrono::sleep_for

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c515206ca4832cb58a96195db13d03