### PR TITLE
refactor(core): move TaskExecutor to detail

### DIFF
--- a/include/logit_cpp/LogIt.hpp
+++ b/include/logit_cpp/LogIt.hpp
@@ -8,7 +8,6 @@
 #include "LogItConfig.hpp"
 #include "logit/enums.hpp"
 #include "logit/utils.hpp"
-#include "logit/TaskExecutor.hpp"
 #include "logit/Logger.hpp"
 #include "logit/LogStream.hpp"
 #include "logit/LogMacros.hpp"

--- a/include/logit_cpp/logit/Logger.hpp
+++ b/include/logit_cpp/logit/Logger.hpp
@@ -7,6 +7,7 @@
 
 #include "loggers/ILogger.hpp"
 #include "formatter.hpp"
+#include "logit/detail/TaskExecutor.hpp"
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -239,7 +240,7 @@ namespace logit {
             if (m_shutdown) return;
             m_shutdown = true;
             wait();
-            TaskExecutor::get_instance().shutdown();
+            detail::TaskExecutor::get_instance().shutdown();
         }
 
     private:

--- a/include/logit_cpp/logit/detail/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/detail/TaskExecutor.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef _LOGIT_TASK_EXECUTOR_HPP_INCLUDED
-#define _LOGIT_TASK_EXECUTOR_HPP_INCLUDED
+#ifndef _LOGIT_DETAIL_TASK_EXECUTOR_HPP_INCLUDED
+#define _LOGIT_DETAIL_TASK_EXECUTOR_HPP_INCLUDED
 
 /// \file TaskExecutor.hpp
 /// \brief Defines the TaskExecutor class, which manages task execution in a separate thread.
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <chrono>
 
-namespace logit {
+namespace logit { namespace detail {
 
 #if defined(__EMSCRIPTEN__)
 
@@ -136,6 +136,6 @@ namespace logit {
 
 #endif // defined(__EMSCRIPTEN__)
 
-}; // namespace logit
+}} // namespace logit::detail
 
-#endif // _LOGIT_TASK_EXECUTOR_HPP_INCLUDED
+#endif // _LOGIT_DETAIL_TASK_EXECUTOR_HPP_INCLUDED

--- a/include/logit_cpp/logit/loggers/ConsoleLogger.hpp
+++ b/include/logit_cpp/logit/loggers/ConsoleLogger.hpp
@@ -6,6 +6,7 @@
 /// \brief Console logger implementation that outputs logs to the console with color support.
 
 #include "ILogger.hpp"
+#include "logit/detail/TaskExecutor.hpp"
 #include <iostream>
 #if defined(_WIN32)
 #include <windows.h>
@@ -105,7 +106,7 @@ namespace logit {
                 return;
             }
             lock.unlock();
-            TaskExecutor::get_instance().add_task([this, message](){
+            detail::TaskExecutor::get_instance().add_task([this, message](){
                 std::lock_guard<std::mutex> lock(m_mutex);
 #               if defined(_WIN32)
                 // For Windows, parse the message for ANSI color codes and apply them
@@ -181,7 +182,7 @@ namespace logit {
             std::unique_lock<std::mutex> lock(m_mutex);
             if (!m_config.async) return;
             lock.unlock();
-            TaskExecutor::get_instance().wait();
+            detail::TaskExecutor::get_instance().wait();
 #endif
         }
 

--- a/include/logit_cpp/logit/loggers/FileLogger.hpp
+++ b/include/logit_cpp/logit/loggers/FileLogger.hpp
@@ -6,6 +6,7 @@
 /// \brief File logger implementation that outputs logs to files with rotation and deletion of old logs.
 
 #include "ILogger.hpp"
+#include "logit/detail/TaskExecutor.hpp"
 #include <iostream>
 #include <fstream>
 #include <mutex>
@@ -117,7 +118,7 @@ namespace logit {
                 return;
             }
             auto timestamp_ms = record.timestamp_ms;
-            TaskExecutor::get_instance().add_task([this, message, timestamp_ms]() {
+            detail::TaskExecutor::get_instance().add_task([this, message, timestamp_ms]() {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 try {
                     write_log(message, timestamp_ms);
@@ -181,7 +182,7 @@ namespace logit {
         /// \brief Waits for all asynchronous tasks to complete.
         void wait() override {
             if (!m_config.async) return;
-            TaskExecutor::get_instance().wait();
+            detail::TaskExecutor::get_instance().wait();
         }
 
     private:

--- a/include/logit_cpp/logit/loggers/UniqueFileLogger.hpp
+++ b/include/logit_cpp/logit/loggers/UniqueFileLogger.hpp
@@ -6,6 +6,7 @@
 /// \brief Logger that writes each log message to a unique file with auto-deletion of old logs.
 
 #include "ILogger.hpp"
+#include "logit/detail/TaskExecutor.hpp"
 #include <iostream>
 #include <fstream>
 #include <mutex>
@@ -163,7 +164,7 @@ namespace logit {
             info_lock.unlock();
 
             auto timestamp_ms = record.timestamp_ms;
-            TaskExecutor::get_instance().add_task([this, message, timestamp_ms, thread_id]() {
+            detail::TaskExecutor::get_instance().add_task([this, message, timestamp_ms, thread_id]() {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 std::string file_path;
                 try {
@@ -253,7 +254,7 @@ namespace logit {
         /// \brief Waits for all asynchronous tasks to complete.
         void wait() override {
             if (!m_config.async) return;
-            TaskExecutor::get_instance().wait();
+            detail::TaskExecutor::get_instance().wait();
         }
 
     private:


### PR DESCRIPTION
## Summary
- move TaskExecutor implementation into `logit::detail`
- update loggers to include and use the internal TaskExecutor
- drop TaskExecutor from the public `LogIt.hpp` umbrella header

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c5169f8f68832c8cb8d29b8c96a8e7