### PR TITLE
test(log): verify log level macros

### DIFF
--- a/include/logit_cpp/logit/LogMacros.hpp
+++ b/include/logit_cpp/logit/LogMacros.hpp
@@ -29,6 +29,15 @@
 #define LOGIT_LEVEL_ERROR 4
 #define LOGIT_LEVEL_FATAL 5
 
+#ifdef _LOGIT_ENUMS_HPP_INCLUDED
+static_assert(LOGIT_LEVEL_TRACE == static_cast<int>(logit::LogLevel::LOG_LVL_TRACE));
+static_assert(LOGIT_LEVEL_DEBUG == static_cast<int>(logit::LogLevel::LOG_LVL_DEBUG));
+static_assert(LOGIT_LEVEL_INFO  == static_cast<int>(logit::LogLevel::LOG_LVL_INFO));
+static_assert(LOGIT_LEVEL_WARN  == static_cast<int>(logit::LogLevel::LOG_LVL_WARN));
+static_assert(LOGIT_LEVEL_ERROR == static_cast<int>(logit::LogLevel::LOG_LVL_ERROR));
+static_assert(LOGIT_LEVEL_FATAL == static_cast<int>(logit::LogLevel::LOG_LVL_FATAL));
+#endif // _LOGIT_ENUMS_HPP_INCLUDED
+
 #ifndef LOGIT_COMPILED_LEVEL
 #    define LOGIT_COMPILED_LEVEL LOGIT_LEVEL_TRACE
 #endif


### PR DESCRIPTION
## Summary
- ensure LOGIT_LEVEL_* macros match LogLevel enum via static assertions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c61fd8b55c832c8cb373dbe11a8e6e