### PR TITLE
feat: add size-based rotation for FileLogger

### DIFF
--- a/include/logit_cpp/logit/LogMacros.hpp
+++ b/include/logit_cpp/logit/LogMacros.hpp
@@ -922,6 +922,25 @@ static_assert(LOGIT_LEVEL_FATAL == static_cast<int>(logit::LogLevel::LOG_LVL_FAT
         std::make_unique<logit::SimpleLogFormatter>(LOGIT_FILE_LOGGER_PATTERN), \
         true)
 
+#define LOGIT_ADD_FILE_LOGGER_WITH_ROTATION(dir, async, days, pattern, max_bytes, max_files) \
+    logit::Logger::get_instance().add_logger( \
+        std::make_unique<logit::FileLogger>(dir, async, days, max_bytes, max_files), \
+        std::make_unique<logit::SimpleLogFormatter>(pattern))
+
+#define LOGIT_ADD_FILE_LOGGER_WITH_ROTATION_SINGLE_MODE(dir, async, days, pattern, max_bytes, max_files) \
+    logit::Logger::get_instance().add_logger( \
+        std::make_unique<logit::FileLogger>(dir, async, days, max_bytes, max_files), \
+        std::make_unique<logit::SimpleLogFormatter>(pattern), \
+        true)
+
+#define LOGIT_ADD_FILE_LOGGER_DEFAULT_WITH_ROTATION() \
+    logit::Logger::get_instance().add_logger( \
+        std::make_unique<logit::FileLogger>( \
+            LOGIT_FILE_LOGGER_PATH, true, LOGIT_FILE_LOGGER_AUTO_DELETE_DAYS, \
+            LOGIT_FILE_LOGGER_MAX_FILE_SIZE_BYTES, LOGIT_FILE_LOGGER_MAX_ROTATED_FILES, \
+            LOGIT_FILE_LOGGER_COMPRESS_ROTATED, LOGIT_FILE_LOGGER_COMPRESS_CMD), \
+        std::make_unique<logit::SimpleLogFormatter>(LOGIT_FILE_LOGGER_PATTERN))
+
 /// \brief Macro for adding a unique file logger with custom parameters.
 /// \param directory The directory where log files will be stored.
 /// \param async Boolean indicating whether logging should be asynchronous (true) or synchronous (false).
@@ -1092,6 +1111,27 @@ static_assert(LOGIT_LEVEL_FATAL == static_cast<int>(logit::LogLevel::LOG_LVL_FAT
         std::unique_ptr<logit::SimpleLogFormatter>(                         \
             new logit::SimpleLogFormatter(LOGIT_FILE_LOGGER_PATTERN)),      \
         true)
+
+#define LOGIT_ADD_FILE_LOGGER_WITH_ROTATION(dir, async, days, pattern, max_bytes, max_files) \
+    logit::Logger::get_instance().add_logger( \
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger( \
+            dir, async, days, max_bytes, max_files)), \
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter(pattern)))
+
+#define LOGIT_ADD_FILE_LOGGER_WITH_ROTATION_SINGLE_MODE(dir, async, days, pattern, max_bytes, max_files) \
+    logit::Logger::get_instance().add_logger( \
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger( \
+            dir, async, days, max_bytes, max_files)), \
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter(pattern)), \
+        true)
+
+#define LOGIT_ADD_FILE_LOGGER_DEFAULT_WITH_ROTATION() \
+    logit::Logger::get_instance().add_logger( \
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger( \
+            LOGIT_FILE_LOGGER_PATH, true, LOGIT_FILE_LOGGER_AUTO_DELETE_DAYS, \
+            LOGIT_FILE_LOGGER_MAX_FILE_SIZE_BYTES, LOGIT_FILE_LOGGER_MAX_ROTATED_FILES, \
+            LOGIT_FILE_LOGGER_COMPRESS_ROTATED, LOGIT_FILE_LOGGER_COMPRESS_CMD)), \
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter(LOGIT_FILE_LOGGER_PATTERN)))
 
 /// \brief Macro for adding a unique file logger with custom parameters.
 /// \param directory The directory where log files will be stored.

--- a/include/logit_cpp/logit/config.hpp
+++ b/include/logit_cpp/logit/config.hpp
@@ -111,6 +111,19 @@
     #define LOGIT_FILE_LOGGER_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%-5l] [%60!@] [thread:%t] %SC%v"
 #endif
 
+#ifndef LOGIT_FILE_LOGGER_MAX_FILE_SIZE_BYTES
+    #define LOGIT_FILE_LOGGER_MAX_FILE_SIZE_BYTES 0
+#endif
+#ifndef LOGIT_FILE_LOGGER_MAX_ROTATED_FILES
+    #define LOGIT_FILE_LOGGER_MAX_ROTATED_FILES 0
+#endif
+#ifndef LOGIT_FILE_LOGGER_COMPRESS_ROTATED
+    #define LOGIT_FILE_LOGGER_COMPRESS_ROTATED 0
+#endif
+#ifndef LOGIT_FILE_LOGGER_COMPRESS_CMD
+    #define LOGIT_FILE_LOGGER_COMPRESS_CMD ""
+#endif
+
 /// \brief Defines the default log pattern for unique file-based loggers.
 /// If `LOGIT_UNIQUE_FILE_LOGGER_PATTERN` is not defined, it defaults to "%v".
 #ifndef LOGIT_UNIQUE_FILE_LOGGER_PATTERN

--- a/tests/file_logger_rotation_test.cpp
+++ b/tests/file_logger_rotation_test.cpp
@@ -1,0 +1,18 @@
+#define LOGIT_FILE_LOGGER_PATH "."
+#include <LogIt.hpp>
+#include <fstream>
+#include <string>
+
+int main() {
+    LOGIT_ADD_FILE_LOGGER_WITH_ROTATION(".", true, 30, "%v", 20, 10);
+    const std::string msg = "0123456789"; // 10 bytes
+    LOGIT_INFO(msg);
+    LOGIT_INFO(msg);
+    LOGIT_WAIT();
+    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
+    std::string rotated = current;
+    size_t pos = rotated.rfind(".log");
+    rotated.insert(pos, ".1");
+    std::ifstream in(rotated);
+    return in.good() ? 0 : 1;
+}

--- a/tests/file_logger_test.cpp
+++ b/tests/file_logger_test.cpp
@@ -11,6 +11,10 @@ int main() {
     const std::string log_path = LOGIT_GET_LAST_FILE_PATH(0);
     std::ifstream in(log_path);
     std::string line;
-    std::getline(in, line);
-    return line.find(message) != std::string::npos ? 0 : 1;
+    while (std::getline(in, line)) {
+        if (line.find(message) != std::string::npos) {
+            return 0;
+        }
+    }
+    return 1;
 }


### PR DESCRIPTION
## Summary
- support size-based log rotation in FileLogger with optional compression
- expose rotation options via config macros and new helper macros
- cover rotation behavior with new tests

## Testing
- `cmake --build .`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68c62cc912d0832cafdb95f24cce8dad