### PR TITLE
test(compiled-level): add coverage for level-dependent macros

### DIFF
--- a/tests/compiled_level_test.cpp
+++ b/tests/compiled_level_test.cpp
@@ -8,9 +8,56 @@ int should_not_compile() {
 }
 
 int main() {
+    // TRACE macros
     LOGIT_TRACE(should_not_compile<int>());
-    LOGIT_DEBUG(should_not_compile<int>());
     LOGIT_TRACE0();
+    LOGIT_0TRACE();
+    LOGIT_0_TRACE();
+    LOGIT_NOARGS_TRACE();
+    LOGIT_FORMAT_TRACE("%d", should_not_compile<int>());
+    LOGIT_PRINT_TRACE(should_not_compile<int>());
+    LOGIT_PRINTF_TRACE("%d", should_not_compile<int>());
+    LOGIT_TRACE_TO(0, should_not_compile<int>());
+    LOGIT_TRACE0_TO(0);
+    LOGIT_0TRACE_TO(0);
+    LOGIT_0_TRACE_TO(0);
+    LOGIT_NOARGS_TRACE_TO(0);
+    LOGIT_FORMAT_TRACE_TO(0, "%d", should_not_compile<int>());
+    LOGIT_PRINT_TRACE_TO(0, should_not_compile<int>());
+    LOGIT_PRINTF_TRACE_TO(0, "%d", should_not_compile<int>());
+    LOGIT_TRACE_IF(false, should_not_compile<int>());
+    LOGIT_TRACE0_IF(false);
+    LOGIT_0TRACE_IF(false);
+    LOGIT_0_TRACE_IF(false);
+    LOGIT_NOARGS_TRACE_IF(false);
+    LOGIT_FORMAT_TRACE_IF(false, "%d", should_not_compile<int>());
+    LOGIT_PRINT_TRACE_IF(false, should_not_compile<int>());
+    LOGIT_PRINTF_TRACE_IF(false, "%d", should_not_compile<int>());
+
+    // DEBUG macros
+    LOGIT_DEBUG(should_not_compile<int>());
     LOGIT_DEBUG0();
+    LOGIT_0DEBUG();
+    LOGIT_0_DEBUG();
+    LOGIT_NOARGS_DEBUG();
+    LOGIT_FORMAT_DEBUG("%d", should_not_compile<int>());
+    LOGIT_PRINT_DEBUG(should_not_compile<int>());
+    LOGIT_PRINTF_DEBUG("%d", should_not_compile<int>());
+    LOGIT_DEBUG_TO(0, should_not_compile<int>());
+    LOGIT_DEBUG0_TO(0);
+    LOGIT_0DEBUG_TO(0);
+    LOGIT_0_DEBUG_TO(0);
+    LOGIT_NOARGS_DEBUG_TO(0);
+    LOGIT_FORMAT_DEBUG_TO(0, "%d", should_not_compile<int>());
+    LOGIT_PRINT_DEBUG_TO(0, should_not_compile<int>());
+    LOGIT_PRINTF_DEBUG_TO(0, "%d", should_not_compile<int>());
+    LOGIT_DEBUG_IF(false, should_not_compile<int>());
+    LOGIT_DEBUG0_IF(false);
+    LOGIT_0DEBUG_IF(false);
+    LOGIT_0_DEBUG_IF(false);
+    LOGIT_NOARGS_DEBUG_IF(false);
+    LOGIT_FORMAT_DEBUG_IF(false, "%d", should_not_compile<int>());
+    LOGIT_PRINT_DEBUG_IF(false, should_not_compile<int>());
+    LOGIT_PRINTF_DEBUG_IF(false, "%d", should_not_compile<int>());
     return 0;
 }


### PR DESCRIPTION
## Summary
- exercise every TRACE and DEBUG macro controlled by `LOGIT_COMPILED_LEVEL`

## Testing
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c6301d46f8832c857b8e728923998e