### PR TITLE
docs: add badges for language, platforms and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # LogIt++ Library
 ![LogIt++ Logo](docs/logo-640x320.png)
 
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS%20%7C%20Emscripten-blue)
+![C++ Standard](https://img.shields.io/badge/C++-11--17-orange)
+![CI Windows](https://img.shields.io/github/actions/workflow/status/NewYaroslav/log-it-cpp/ci.yml?branch=main&label=Windows&logo=windows)
+![CI Linux](https://img.shields.io/github/actions/workflow/status/NewYaroslav/log-it-cpp/ci.yml?branch=main&label=Linux&logo=linux)
+![CI macOS](https://img.shields.io/github/actions/workflow/status/NewYaroslav/log-it-cpp/ci.yml?branch=main&label=macOS&logo=apple)
+
 [Читать на русском](README-RU.md)
 
 ## Introduction


### PR DESCRIPTION
## Summary
- add license, platform, C++ standard and CI badges to README

## Testing
- `cmake -S . -B build -DLOG_IT_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c657b128832c88ac631876e2fad2