### PR TITLE
chore(packaging): add pkg-config and vcpkg fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ if(NOT TimeShield_FOUND)
 endif()
 
 add_library(log-it-cpp INTERFACE)
+add_library(log-it-cpp::log-it-cpp ALIAS log-it-cpp)
 
 add_compile_definitions(LOGIT_BASE_PATH="$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 
@@ -132,14 +133,25 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 
-configure_package_config_file(
-    cmake/log-it-cppConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/log-it-cpp
-)
+  configure_package_config_file(
+      cmake/log-it-cppConfig.cmake.in
+      "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfig.cmake"
+      INSTALL_DESTINATION lib/cmake/log-it-cpp
+  )
 
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfigVersion.cmake"
-    DESTINATION lib/cmake/log-it-cpp
-)
+  configure_file(
+      cmake/log-it-cpp.pc.in
+      "${CMAKE_CURRENT_BINARY_DIR}/log-it-cpp.pc"
+      @ONLY
+  )
+
+  install(FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfig.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/log-it-cppConfigVersion.cmake"
+      DESTINATION lib/cmake/log-it-cpp
+  )
+
+  install(FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/log-it-cpp.pc"
+      DESTINATION share/pkgconfig
+  )

--- a/cmake/log-it-cpp.pc.in
+++ b/cmake/log-it-cpp.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: log-it-cpp
+Description: LogIt C++ logging library
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs:

--- a/vcpkg-overlay/ports/log-it-cpp/portfile.cmake
+++ b/vcpkg-overlay/ports/log-it-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    MAYBE_UNUSED_VARIABLES LOGIT_WITH_SYSLOG LOGIT_WITH_WIN_EVENT_LOG
     OPTIONS
       -DLOG_IT_CPP_BUILD_TESTS=OFF
       -DLOGIT_WITH_SYSLOG=ON
@@ -18,10 +19,11 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME log-it-cpp CONFIG_PATH lib/cmake/log-it-cpp)
 
+vcpkg_fixup_pkgconfig()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/lib"
-    "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
 )


### PR DESCRIPTION
## Summary
- add imported target alias and pkg-config file
- polish vcpkg port with pkg-config fixup and clean directories

## Testing
- `cmake -S . -B build -DLOG_IT_CPP_BUILD_TESTS=OFF`
- `cmake --build build`
- `cmake --install build --prefix install`
- `cmake -S tests/install_consumer -B build-install-consumer -Dlog-it-cpp_DIR=$(pwd)/install/lib/cmake/log-it-cpp -DCMAKE_PREFIX_PATH=$(pwd)/install`
- `cmake --build build-install-consumer`
- `/tmp/vcpkg/vcpkg install log-it-cpp --overlay-ports=./vcpkg-overlay/ports --overlay-ports=/tmp/ts-overlay/ports --x-install-root=$(pwd)/vcpkg-installed`


------
https://chatgpt.com/codex/tasks/task_e_68c6f79c99c0832c8524cd44752a3c12