### PR TITLE
test(file-logger): add rotation naming tests

### DIFF
--- a/tests/file_logger_rotation_naming_sequence_test.cpp
+++ b/tests/file_logger_rotation_naming_sequence_test.cpp
@@ -1,0 +1,31 @@
+#include <LogIt.hpp>
+#include <regex>
+#include <string>
+#include <fstream>
+#include <cstdlib>
+
+int main() {
+    std::system("rm -rf rotation_seq");
+    logit::FileLogger::Config cfg;
+    cfg.directory = "rotation_seq";
+    cfg.max_file_size_bytes = 20;
+    cfg.naming = logit::RotationNaming::Sequence;
+    logit::Logger::get_instance().add_logger(
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));
+    const std::string msg = "0123456789";
+    LOGIT_INFO(msg);
+    LOGIT_INFO(msg);
+    LOGIT_WAIT();
+    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
+    LOGIT_SHUTDOWN();
+    size_t pos = current.rfind(".log");
+    if (pos == std::string::npos) return 1;
+    std::string rotated = current;
+    rotated.insert(pos, ".001");
+    std::string name = rotated.substr(rotated.find_last_of("/\\") + 1);
+    std::regex re("\\d{4}-\\d{2}-\\d{2}\\.001\\.log");
+    if (!std::regex_match(name, re)) return 1;
+    std::ifstream f(rotated.c_str());
+    return f.good() ? 0 : 1;
+}

--- a/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
@@ -2,10 +2,25 @@
 #include <regex>
 #include <string>
 #include <vector>
+#if __cplusplus >= 201703L
 #include <filesystem>
+#else
+#include <cstdlib>
+#endif
 
 int main() {
+#if __cplusplus >= 201703L
     std::filesystem::remove_all(logit::get_exec_dir() + "/rotation_tms");
+#else
+#ifdef _WIN32
+    std::string clean = logit::get_exec_dir() + "\\rotation_tms";
+    std::string cmd = "rmdir /s /q \"" + clean + "\"";
+#else
+    std::string clean = logit::get_exec_dir() + "/rotation_tms";
+    std::string cmd = "rm -rf \"" + clean + "\"";
+#endif
+    std::system(cmd.c_str());
+#endif
     const std::string dir = logit::get_exec_dir() + "/rotation_tms";
     logit::FileLogger::Config cfg;
     cfg.directory = "rotation_tms";

--- a/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
@@ -2,15 +2,15 @@
 #include <regex>
 #include <string>
 #include <vector>
-#include <cstdlib>
+#include <filesystem>
 
 int main() {
-    std::system("rm -rf rotation_tms");
+    std::filesystem::remove_all(logit::get_exec_dir() + "/rotation_tms");
+    const std::string dir = logit::get_exec_dir() + "/rotation_tms";
     logit::FileLogger::Config cfg;
     cfg.directory = "rotation_tms";
     cfg.max_file_size_bytes = 20;
     cfg.naming = logit::RotationNaming::TimestampMs;
-    const std::string dir = cfg.directory;
     logit::Logger::get_instance().add_logger(
         std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
         std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));

--- a/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
@@ -1,0 +1,30 @@
+#include <LogIt.hpp>
+#include <regex>
+#include <string>
+#include <vector>
+#include <cstdlib>
+
+int main() {
+    std::system("rm -rf rotation_tms");
+    logit::FileLogger::Config cfg;
+    cfg.directory = "rotation_tms";
+    cfg.max_file_size_bytes = 20;
+    cfg.naming = logit::RotationNaming::TimestampMs;
+    logit::Logger::get_instance().add_logger(
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));
+    const std::string msg = "0123456789";
+    LOGIT_INFO(msg);
+    LOGIT_INFO(msg);
+    LOGIT_WAIT();
+    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
+    std::string base_dir = current.substr(0, current.find_last_of("/\\"));
+    std::vector<std::string> files = logit::get_list_files(base_dir);
+    LOGIT_SHUTDOWN();
+    std::regex re("\\d{4}-\\d{2}-\\d{2}_\\d{9}(?:\\.\\d+)?\\.log");
+    for (const auto& path : files) {
+        std::string name = path.substr(path.find_last_of("/\\") + 1);
+        if (std::regex_match(name, re)) return 0;
+    }
+    return 1;
+}

--- a/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_ms_test.cpp
@@ -10,6 +10,7 @@ int main() {
     cfg.directory = "rotation_tms";
     cfg.max_file_size_bytes = 20;
     cfg.naming = logit::RotationNaming::TimestampMs;
+    const std::string dir = cfg.directory;
     logit::Logger::get_instance().add_logger(
         std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
         std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));
@@ -17,10 +18,8 @@ int main() {
     LOGIT_INFO(msg);
     LOGIT_INFO(msg);
     LOGIT_WAIT();
-    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
-    std::string base_dir = current.substr(0, current.find_last_of("/\\"));
-    std::vector<std::string> files = logit::get_list_files(base_dir);
     LOGIT_SHUTDOWN();
+    std::vector<std::string> files = logit::get_list_files(dir);
     std::regex re("\\d{4}-\\d{2}-\\d{2}_\\d{9}(?:\\.\\d+)?\\.log");
     for (const auto& path : files) {
         std::string name = path.substr(path.find_last_of("/\\") + 1);

--- a/tests/file_logger_rotation_naming_timestamp_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_test.cpp
@@ -10,6 +10,7 @@ int main() {
     cfg.directory = "rotation_ts";
     cfg.max_file_size_bytes = 20;
     cfg.naming = logit::RotationNaming::Timestamp;
+    const std::string dir = cfg.directory;
     logit::Logger::get_instance().add_logger(
         std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
         std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));
@@ -17,10 +18,8 @@ int main() {
     LOGIT_INFO(msg);
     LOGIT_INFO(msg);
     LOGIT_WAIT();
-    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
-    std::string base_dir = current.substr(0, current.find_last_of("/\\"));
-    std::vector<std::string> files = logit::get_list_files(base_dir);
     LOGIT_SHUTDOWN();
+    std::vector<std::string> files = logit::get_list_files(dir);
     std::regex re("\\d{4}-\\d{2}-\\d{2}_\\d{6}(?:\\.\\d+)?\\.log");
     for (const auto& path : files) {
         std::string name = path.substr(path.find_last_of("/\\") + 1);

--- a/tests/file_logger_rotation_naming_timestamp_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_test.cpp
@@ -1,0 +1,30 @@
+#include <LogIt.hpp>
+#include <regex>
+#include <string>
+#include <vector>
+#include <cstdlib>
+
+int main() {
+    std::system("rm -rf rotation_ts");
+    logit::FileLogger::Config cfg;
+    cfg.directory = "rotation_ts";
+    cfg.max_file_size_bytes = 20;
+    cfg.naming = logit::RotationNaming::Timestamp;
+    logit::Logger::get_instance().add_logger(
+        std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
+        std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));
+    const std::string msg = "0123456789";
+    LOGIT_INFO(msg);
+    LOGIT_INFO(msg);
+    LOGIT_WAIT();
+    std::string current = LOGIT_GET_LAST_FILE_PATH(0);
+    std::string base_dir = current.substr(0, current.find_last_of("/\\"));
+    std::vector<std::string> files = logit::get_list_files(base_dir);
+    LOGIT_SHUTDOWN();
+    std::regex re("\\d{4}-\\d{2}-\\d{2}_\\d{6}(?:\\.\\d+)?\\.log");
+    for (const auto& path : files) {
+        std::string name = path.substr(path.find_last_of("/\\") + 1);
+        if (std::regex_match(name, re)) return 0;
+    }
+    return 1;
+}

--- a/tests/file_logger_rotation_naming_timestamp_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_test.cpp
@@ -2,10 +2,25 @@
 #include <regex>
 #include <string>
 #include <vector>
+#if __cplusplus >= 201703L
 #include <filesystem>
+#else
+#include <cstdlib>
+#endif
 
 int main() {
+#if __cplusplus >= 201703L
     std::filesystem::remove_all(logit::get_exec_dir() + "/rotation_ts");
+#else
+#ifdef _WIN32
+    std::string clean = logit::get_exec_dir() + "\\rotation_ts";
+    std::string cmd = "rmdir /s /q \"" + clean + "\"";
+#else
+    std::string clean = logit::get_exec_dir() + "/rotation_ts";
+    std::string cmd = "rm -rf \"" + clean + "\"";
+#endif
+    std::system(cmd.c_str());
+#endif
     const std::string dir = logit::get_exec_dir() + "/rotation_ts";
     logit::FileLogger::Config cfg;
     cfg.directory = "rotation_ts";

--- a/tests/file_logger_rotation_naming_timestamp_test.cpp
+++ b/tests/file_logger_rotation_naming_timestamp_test.cpp
@@ -2,15 +2,15 @@
 #include <regex>
 #include <string>
 #include <vector>
-#include <cstdlib>
+#include <filesystem>
 
 int main() {
-    std::system("rm -rf rotation_ts");
+    std::filesystem::remove_all(logit::get_exec_dir() + "/rotation_ts");
+    const std::string dir = logit::get_exec_dir() + "/rotation_ts";
     logit::FileLogger::Config cfg;
     cfg.directory = "rotation_ts";
     cfg.max_file_size_bytes = 20;
     cfg.naming = logit::RotationNaming::Timestamp;
-    const std::string dir = cfg.directory;
     logit::Logger::get_instance().add_logger(
         std::unique_ptr<logit::FileLogger>(new logit::FileLogger(cfg)),
         std::unique_ptr<logit::SimpleLogFormatter>(new logit::SimpleLogFormatter("%v")));

--- a/tests/file_logger_rotation_test.cpp
+++ b/tests/file_logger_rotation_test.cpp
@@ -16,14 +16,18 @@ int main() {
     std::filesystem::path current = LOGIT_GET_LAST_FILE_PATH(0);
     std::filesystem::path rotated = current;
     rotated.replace_filename(current.stem().string() + ".001.log");
-    return std::filesystem::exists(rotated) ? 0 : 1;
+    bool exists = std::filesystem::exists(rotated);
 #else
     std::string current = LOGIT_GET_LAST_FILE_PATH(0);
     std::string rotated = current;
     size_t pos = rotated.rfind(".log");
-    if (pos == std::string::npos) return 1;
-    rotated.insert(pos, ".001");
-    std::ifstream f(rotated.c_str());
-    return f.good() ? 0 : 1;
+    bool exists = false;
+    if (pos != std::string::npos) {
+        rotated.insert(pos, ".001");
+        std::ifstream f(rotated.c_str());
+        exists = f.good();
+    }
 #endif
+    LOGIT_SHUTDOWN();
+    return exists ? 0 : 1;
 }

--- a/tests/file_logger_rotation_test.cpp
+++ b/tests/file_logger_rotation_test.cpp
@@ -12,22 +12,26 @@ int main() {
     LOGIT_INFO(msg);
     LOGIT_INFO(msg);
     LOGIT_WAIT();
+    
 #if __cplusplus >= 201703L
     std::filesystem::path current = LOGIT_GET_LAST_FILE_PATH(0);
     std::filesystem::path rotated = current;
     rotated.replace_filename(current.stem().string() + ".001.log");
+    LOGIT_SHUTDOWN();
     bool exists = std::filesystem::exists(rotated);
 #else
     std::string current = LOGIT_GET_LAST_FILE_PATH(0);
     std::string rotated = current;
     size_t pos = rotated.rfind(".log");
-    bool exists = false;
     if (pos != std::string::npos) {
         rotated.insert(pos, ".001");
+    }
+    LOGIT_SHUTDOWN();
+    bool exists = false;
+    if (pos != std::string::npos) {
         std::ifstream f(rotated.c_str());
         exists = f.good();
     }
 #endif
-    LOGIT_SHUTDOWN();
     return exists ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- verify rotated filenames for sequence naming policy
- assert timestamp-based rotated filenames for second-level and millisecond resolution

## Testing
- `ctest -R file_logger_rotation_naming_ --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c701d1b838832cb41e7717d2adb7d1