### PR TITLE
Add sanitizer builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,36 @@ jobs:
             build/Testing/Temporary/LastTest.log
           if-no-files-found: ignore
 
+  asan-ubsan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: git submodule update --init --recursive
+      - name: Configure
+        run: cmake -S . -B build -DLOG_IT_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined' -DCMAKE_LINKER_FLAGS='-fsanitize=address,undefined'
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
+
+  tsan:
+    runs-on: ubuntu-latest
+    env:
+      LOGIT_PROFILE: thread
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: git submodule update --init --recursive
+      - name: Configure
+        run: cmake -S . -B build -DLOG_IT_CPP_BUILD_TESTS=ON -DLOGIT_FORCE_ASYNC_OFF=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS='-fsanitize=thread' -DCMAKE_LINKER_FLAGS='-fsanitize=thread'
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
+
   vcpkg-install:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- build and test with address and undefined behavior sanitizers
- add ThreadSanitizer build using thread profile

## Testing
- `yamllint -d "{rules: {line-length: disable, truthy: disable, brackets: disable, document-start: disable}}" .github/workflows/ci.yml`
- `python - <<'PY'
import yaml, sys
with open('.github/workflows/ci.yml') as f:
    yaml.safe_load(f)
print('YAML load ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c750785fc4832ca813a79bbd37202d