### PR TITLE
feat(macros): add throttling and tagging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ try {
 > 23:59:59.128 | An example runtime error
 ```
 
-- **Macro-Based Logging**: 
+- **Macro-Based Logging**:
 
 Easily log variables and messages using macros. Simply choose the appropriate macro and pass variables or arguments to it.
 
@@ -49,6 +49,25 @@ LOGIT_INFO(someFloat, someInt);
 
 auto now = std::chrono::system_clock::now();
 LOGIT_PRINT_INFO("TimePoint example: ", now);
+```
+
+- **Log Filters and Throttling**:
+
+Reduce noise from repetitive messages with macros like `LOGIT_WARN_ONCE`, `LOGIT_INFO_EVERY_N`, and `LOGIT_ERROR_THROTTLE`.
+
+```cpp
+for (int i = 0; i < 1000; ++i) {
+    LOGIT_INFO_EVERY_N(100, "heartbeat");
+}
+```
+
+- **Tagged Logging**:
+
+Attach simple key-value attributes for easier filtering in log aggregators.
+
+```cpp
+LOGIT_INFO_TAG(({{"order_id", 123}, {"side", "BUY"}}), "sent order");
+// Output: [info] sent order order_id=123 side=BUY
 ```
 
 - **Rotating File Logs**:

--- a/include/logit_cpp/logit/utils.hpp
+++ b/include/logit_cpp/logit/utils.hpp
@@ -16,5 +16,6 @@
 #include "utils/encoding_utils.hpp"
 #include "utils/path_utils.hpp"
 #include "utils/LogRecord.hpp"
+#include "utils/tag_utils.hpp"
 
 #endif // _LOGIT_UTILS_HPP_INCLUDED

--- a/include/logit_cpp/logit/utils/tag_utils.hpp
+++ b/include/logit_cpp/logit/utils/tag_utils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef _LOGIT_TAG_UTILS_HPP_INCLUDED
+#define _LOGIT_TAG_UTILS_HPP_INCLUDED
+
+#include <sstream>
+#include <string>
+
+namespace logit {
+namespace detail {
+
+    /// \brief Formats tags as key=value pairs separated by spaces.
+    /// \tparam Tags Container of pairs convertible to output stream.
+    /// \param tags Collection of tag key-value pairs.
+    /// \return String in format " key=value ..." or empty string when no tags.
+    template <typename Tags>
+    inline std::string format_tags(const Tags& tags) {
+        std::ostringstream oss;
+        for (const auto& kv : tags) {
+            oss << ' ' << kv.first << '=' << kv.second;
+        }
+        return oss.str();
+    }
+
+    /// \brief Helper to allow passing initializer lists to macros.
+    template <typename K, typename V>
+    inline std::initializer_list<std::pair<K, V>> make_tags(std::initializer_list<std::pair<K, V>> tags) {
+        return tags;
+    }
+
+} // namespace detail
+} // namespace logit
+
+#endif // _LOGIT_TAG_UTILS_HPP_INCLUDED

--- a/tests/log_filters_tags_test.cpp
+++ b/tests/log_filters_tags_test.cpp
@@ -1,0 +1,28 @@
+#include <LogIt.hpp>
+#include <thread>
+#include <chrono>
+
+// Basic smoke test for frequency control macros.
+
+int main() {
+    int once_counter = 0;
+    for (int i = 0; i < 10; ++i) {
+        LOGIT_WARN_ONCE(once_counter++);
+    }
+    if (once_counter != 1) return 1;
+
+    int every_n_counter = 0;
+    for (int i = 0; i < 10; ++i) {
+        LOGIT_INFO_EVERY_N(3, every_n_counter++);
+    }
+    if (every_n_counter != 3) return 1;
+
+    int throttle_counter = 0;
+    LOGIT_ERROR_THROTTLE(50, throttle_counter++);
+    LOGIT_ERROR_THROTTLE(50, throttle_counter++);
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    LOGIT_ERROR_THROTTLE(50, throttle_counter++);
+    if (throttle_counter != 2) return 1;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add LOGIT_*_ONCE, LOGIT_*_EVERY_N and LOGIT_*_THROTTLE macros
- support simple key-value tags via LOGIT_*_TAG macros
- cover new macros with basic smoke test

## Testing
- `g++ -std=c++17 -Iinclude/logit_cpp -Ilibs/time-shield-cpp/include tests/log_filters_tags_test.cpp -o /tmp/log_filters_tags_test && /tmp/log_filters_tags_test`


------
https://chatgpt.com/codex/tasks/task_e_68c75d206240832cbba1f8f684319d76