### PR TITLE
docs: normalize Doxygen comments

### DIFF
--- a/include/logit_cpp/logit/LogMacros.hpp
+++ b/include/logit_cpp/logit/LogMacros.hpp
@@ -28,7 +28,14 @@
 #define LOGIT_LEVEL_WARN  3
 #define LOGIT_LEVEL_ERROR 4
 #define LOGIT_LEVEL_FATAL 5
+/// \brief Concatenate two tokens without macro expansion.
+/// \param x First token.
+/// \param y Second token.
 #define LOGIT_CONCAT_IMPL(x, y) x##y
+
+/// \brief Concatenate two tokens with macro expansion.
+/// \param x First token.
+/// \param y Second token.
 #define LOGIT_CONCAT(x, y) LOGIT_CONCAT_IMPL(x, y)
 
 #ifdef _LOGIT_ENUMS_HPP_INCLUDED

--- a/include/logit_cpp/logit/detail/CompressionWorker.hpp
+++ b/include/logit_cpp/logit/detail/CompressionWorker.hpp
@@ -40,18 +40,26 @@ namespace logit { namespace detail {
     /// \brief Background worker performing asynchronous compression.
     class CompressionWorker {
     public:
+        /// \brief Create worker thread.
+        /// \param type Compression algorithm.
+        /// \param level Compression level.
+        /// \param external_cmd External command template.
         CompressionWorker(CompressType type,
                            int level,
                            std::string external_cmd);
+
+        /// \brief Stop worker thread and finish pending tasks.
         ~CompressionWorker();
 
         /// \brief Enqueue a file for compression.
+        /// \param path Path to file.
         void enqueue(std::string path);
 
         /// \brief Wait until all queued files are processed.
         void wait();
 
     private:
+        /// \brief Worker loop processing queued files.
         void run();
 
         CompressType m_type;
@@ -66,12 +74,22 @@ namespace logit { namespace detail {
         bool m_busy = false;
     };
 
+    /// \brief Clamp value to inclusive range.
+    /// \param v Input value.
+    /// \param lo Lower bound.
+    /// \param hi Upper bound.
+    /// \return Clamped value.
     inline int clamp_level(int v, int lo, int hi) {
         if (v < lo) return lo;
         if (v > hi) return hi;
         return v;
     }
 
+    /// \brief Compress file using gzip.
+    /// \param src Source path.
+    /// \param dst_tmp Temporary output path.
+    /// \param level Compression level.
+    /// \return true on success.
     inline bool compress_file_gzip(const std::string& src,
                                    const std::string& dst_tmp,
                                    int level) {
@@ -100,6 +118,11 @@ namespace logit { namespace detail {
 #       endif
     }
 
+    /// \brief Compress file using Zstandard.
+    /// \param src Source path.
+    /// \param dst_tmp Temporary output path.
+    /// \param level Compression level.
+    /// \return true on success.
     inline bool compress_file_zstd(const std::string& src,
                                    const std::string& dst_tmp,
                                    int level) {
@@ -143,6 +166,11 @@ namespace logit { namespace detail {
 #       endif
     }
 
+    /// \brief Compress file using external command.
+    /// \param src Source path.
+    /// \param cmd_tpl Command template containing {file} and {level}.
+    /// \param level Compression level.
+    /// \return true on success.
     inline bool compress_file_external(const std::string& src,
                                        const std::string& cmd_tpl,
                                        int level) {

--- a/include/logit_cpp/logit/detail/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/detail/TaskExecutor.hpp
@@ -28,13 +28,18 @@ namespace logit { namespace detail {
 
     /// \class TaskExecutor
     /// \brief Simplified task executor for single-threaded Emscripten builds.
+    /// \thread_safety Not thread-safe.
     class TaskExecutor {
     public:
+        /// \brief Obtain singleton instance.
+        /// \return Global executor.
         static TaskExecutor& get_instance() {
             static TaskExecutor instance;
             return instance;
         }
 
+        /// \brief Enqueue task for later execution.
+        /// \param task Callable to execute.
         void add_task(std::function<void()> task) {
             if (!task) return;
             bool schedule = false;
@@ -76,13 +81,21 @@ namespace logit { namespace detail {
             }
         }
 
+        /// \brief Run all queued tasks.
         void wait() { drain(); }
+
+        /// \brief Drain queue without scheduling new tasks.
         void shutdown() { drain(); }
 
+        /// \brief Set maximum queue size.
+        /// \param size Number of tasks allowed (0 for unlimited).
         void set_max_queue_size(std::size_t size) {
             std::lock_guard<std::mutex> lk(m_mutex);
             m_max_queue_size = size;
         }
+
+        /// \brief Set overflow handling policy.
+        /// \param policy Policy to apply.
         void set_queue_policy(QueuePolicy policy) {
             std::lock_guard<std::mutex> lk(m_mutex);
             m_overflow_policy = policy;
@@ -132,6 +145,7 @@ namespace logit { namespace detail {
 
     /// \class TaskExecutor
     /// \brief A thread-safe task executor that processes tasks in a dedicated worker thread.
+    /// \thread_safety Thread-safe.
     ///
     /// This class provides a mechanism for queuing tasks (functions or lambdas) and executing them
     /// asynchronously in a background thread. It follows the singleton design pattern.

--- a/include/logit_cpp/logit/loggers/EventLogLogger.hpp
+++ b/include/logit_cpp/logit/loggers/EventLogLogger.hpp
@@ -6,6 +6,9 @@
 #include <atomic>
 #include <string>
 
+/// \file EventLogLogger.hpp
+/// \brief Logger writing to Windows Event Log.
+
 #if defined(_WIN32) && defined(LOGIT_HAS_WIN_EVENT_LOG)
 #include <windows.h>
 #define LOGIT_WIN_EVENT_ENABLED 1
@@ -17,20 +20,42 @@ namespace logit {
 
 #   if LOGIT_WIN_EVENT_ENABLED
 
+    /// \class EventLogLogger
+    /// \brief Logger forwarding messages to Windows Event Log.
+    /// \thread_safety Thread-safe.
     class EventLogLogger : public ILogger {
     public:
+        /// \brief Runtime configuration.
         struct Config {
-            const wchar_t* source;
-            bool async;
+            const wchar_t* source; ///< Event source name.
+            bool async;           ///< Use TaskExecutor when true.
+            /// \brief Initialize configuration.
+            /// \param s Source name.
+            /// \param a Run asynchronously.
             Config(const wchar_t* s = L"LogIt", bool a = true) : source(s), async(a) {}
         };
+
+        /// \brief Construct with default configuration.
         EventLogLogger() : EventLogLogger(Config()) {}
+
+        /// \brief Construct with explicit configuration.
+        /// \param c Configuration options.
         explicit EventLogLogger(const Config& c) : m_cfg(c) {
             m_hsrc = RegisterEventSourceW(nullptr, m_cfg.source);
         }
-        EventLogLogger(const wchar_t* source, bool async) : EventLogLogger(Config(source, async)) {}
+
+        /// \brief Construct with explicit parameters.
+        /// \param source Event source name.
+        /// \param async Run asynchronously.
+        EventLogLogger(const wchar_t* source, bool async)
+            : EventLogLogger(Config(source, async)) {}
+
+        /// \brief Deregister event source on destruction.
         ~EventLogLogger() override { if (m_hsrc) DeregisterEventSource(m_hsrc); }
 
+        /// \brief Send message to Event Log.
+        /// \param rec Log metadata.
+        /// \param msg UTF-8 message text.
         void log(const LogRecord& rec, const std::string& msg) override {
             LogLevel lvl = rec.log_level;
             std::string s = msg;
@@ -49,11 +74,30 @@ namespace logit {
             m_last_ts.store(rec.timestamp_ms);
         }
 
-        std::string get_string_param(const LoggerParam&) const override { return {}; }
-        int64_t get_int_param(const LoggerParam&) const override { return 0; }
-        double get_float_param(const LoggerParam&) const override { return 0.0; }
+        /// \brief Get string parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or empty string.
+        std::string get_string_param(const LoggerParam& param) const override { return {}; }
+
+        /// \brief Get integer parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or 0.
+        int64_t get_int_param(const LoggerParam& param) const override { return 0; }
+
+        /// \brief Get floating-point parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or 0.0.
+        double get_float_param(const LoggerParam& param) const override { return 0.0; }
+
+        /// \brief Set minimal log level.
+        /// \param l New level.
         void set_log_level(LogLevel l) override { m_level.store((int)l); }
+
+        /// \brief Get current log level.
+        /// \return Minimal log level.
         LogLevel get_log_level() const override { return (LogLevel)m_level.load(); }
+
+        /// \brief Wait for asynchronous tasks to finish.
         void wait() override { if (m_cfg.async) detail::TaskExecutor::get_instance().wait(); }
 
     private:
@@ -74,22 +118,58 @@ namespace logit {
     };
 
 #   else // stub
+    /// \class EventLogLogger
+    /// \brief Stub logger when Windows Event Log is unavailable.
     class EventLogLogger : public ILogger {
     public:
+        /// \brief Stub configuration.
         struct Config {
-            const wchar_t* source;
-            bool async;
+            const wchar_t* source; ///< Unused source name.
+            bool async;           ///< Unused flag.
             Config(const wchar_t* s = L"", bool a = false) : source(s), async(a) {}
         };
+
+        /// \brief Construct stub logger.
         EventLogLogger() {}
-        explicit EventLogLogger(const Config&) {}
-        EventLogLogger(const wchar_t*, bool) {}
-        void log(const LogRecord&, const std::string&) override {}
-        std::string get_string_param(const LoggerParam&) const override { return {}; }
-        int64_t get_int_param(const LoggerParam&) const override { return 0; }
-        double get_float_param(const LoggerParam&) const override { return 0.0; }
-        void set_log_level(LogLevel) override {}
+
+        /// \brief Construct with configuration.
+        /// \param c Ignored configuration.
+        explicit EventLogLogger(const Config& c) { (void)c; }
+
+        /// \brief Construct with parameters.
+        /// \param source Ignored source name.
+        /// \param async Ignored flag.
+        EventLogLogger(const wchar_t* source, bool async) { (void)source; (void)async; }
+
+        /// \brief Ignore log request.
+        /// \param rec Log metadata.
+        /// \param msg Message text.
+        void log(const LogRecord& rec, const std::string& msg) override { (void)rec; (void)msg; }
+
+        /// \brief Return empty string parameter.
+        /// \param param Parameter identifier.
+        /// \return Empty string.
+        std::string get_string_param(const LoggerParam& param) const override { (void)param; return {}; }
+
+        /// \brief Return zero integer parameter.
+        /// \param param Parameter identifier.
+        /// \return Zero.
+        int64_t get_int_param(const LoggerParam& param) const override { (void)param; return 0; }
+
+        /// \brief Return zero float parameter.
+        /// \param param Parameter identifier.
+        /// \return Zero.
+        double get_float_param(const LoggerParam& param) const override { (void)param; return 0.0; }
+
+        /// \brief Ignore level change.
+        /// \param l Desired level.
+        void set_log_level(LogLevel l) override { (void)l; }
+
+        /// \brief Return default log level.
+        /// \return LogLevel::LOG_LVL_TRACE.
         LogLevel get_log_level() const override { return LogLevel::LOG_LVL_TRACE; }
+
+        /// \brief No-op wait.
         void wait() override {}
     };
 #   endif

--- a/include/logit_cpp/logit/loggers/SyslogLogger.hpp
+++ b/include/logit_cpp/logit/loggers/SyslogLogger.hpp
@@ -6,6 +6,9 @@
 #include <atomic>
 #include <string>
 
+/// \file SyslogLogger.hpp
+/// \brief Logger writing to system syslog.
+
 #if (defined(__unix__) || defined(__APPLE__)) && defined(LOGIT_HAS_SYSLOG)
 #include <syslog.h>
 #define LOGIT_SYSLOG_ENABLED 1
@@ -17,24 +20,46 @@ namespace logit {
 
 #   if LOGIT_SYSLOG_ENABLED
 
+    /// \class SyslogLogger
+    /// \brief Logger forwarding messages to syslog.
+    /// \thread_safety Thread-safe.
     class SyslogLogger : public ILogger {
     public:
+        /// \brief Runtime configuration.
         struct Config {
-            const char* ident;
-            int facility;
-            bool async;
+            const char* ident;  ///< Identifier passed to openlog.
+            int facility;       ///< Syslog facility.
+            bool async;         ///< Use TaskExecutor when true.
+            /// \brief Initialize configuration.
+            /// \param i Identifier string.
+            /// \param f Facility code.
+            /// \param a Run asynchronously.
             Config(const char* i = "log-it", int f = LOG_USER, bool a = true)
                 : ident(i), facility(f), async(a) {}
         };
+
+        /// \brief Construct with default configuration.
         SyslogLogger() : SyslogLogger(Config()) {}
 
-        explicit SyslogLogger(const Config& c) : m_cfg(c) { 
-            openlog(m_cfg.ident, LOG_PID | LOG_NDELAY, m_cfg.facility); 
+        /// \brief Construct with explicit configuration.
+        /// \param c Configuration options.
+        explicit SyslogLogger(const Config& c) : m_cfg(c) {
+            openlog(m_cfg.ident, LOG_PID | LOG_NDELAY, m_cfg.facility);
         }
-        
-        SyslogLogger(const char* ident, int facility, bool async) : SyslogLogger(Config(ident, facility, async)) {}
+
+        /// \brief Construct with explicit parameters.
+        /// \param ident Identifier string.
+        /// \param facility Syslog facility.
+        /// \param async Run asynchronously.
+        SyslogLogger(const char* ident, int facility, bool async)
+            : SyslogLogger(Config(ident, facility, async)) {}
+
+        /// \brief Close syslog on destruction.
         ~SyslogLogger() override { closelog(); }
 
+        /// \brief Send message to syslog.
+        /// \param rec Log metadata.
+        /// \param msg Formatted message.
         void log(const LogRecord& rec, const std::string& msg) override {
             LogLevel lvl = rec.log_level;
             std::string s = msg;
@@ -46,11 +71,30 @@ namespace logit {
             else { task(); }
             m_last_ts.store(rec.timestamp_ms);
         }
-        std::string get_string_param(const LoggerParam&) const override { return {}; }
-        int64_t get_int_param(const LoggerParam&) const override { return 0; }
-        double  get_float_param(const LoggerParam&) const override { return 0.0; }
+        /// \brief Get string parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or empty string.
+        std::string get_string_param(const LoggerParam& param) const override { return {}; }
+
+        /// \brief Get integer parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or 0.
+        int64_t get_int_param(const LoggerParam& param) const override { return 0; }
+
+        /// \brief Get floating-point parameter.
+        /// \param param Parameter identifier.
+        /// \return Parameter value or 0.0.
+        double  get_float_param(const LoggerParam& param) const override { return 0.0; }
+
+        /// \brief Set minimal log level.
+        /// \param l New level.
         void set_log_level(LogLevel l) override { m_level.store((int)l); }
+
+        /// \brief Get current log level.
+        /// \return Minimal log level.
         LogLevel get_log_level() const override { return (LogLevel)m_level.load(); }
+
+        /// \brief Wait for asynchronous tasks to finish.
         void wait() override { if (m_cfg.async) detail::TaskExecutor::get_instance().wait(); }
 
     private:
@@ -70,23 +114,60 @@ namespace logit {
     };
 
 #   else // stub on unsupported
+    /// \class SyslogLogger
+    /// \brief Stub logger when syslog is unavailable.
     class SyslogLogger : public ILogger {
     public:
+        /// \brief Stub configuration.
         struct Config {
-            const char* ident;
-            int facility;
-            bool async;
+            const char* ident;  ///< Unused identifier.
+            int facility;       ///< Unused facility.
+            bool async;         ///< Unused flag.
             Config(const char* i="", int f=0, bool a=false) : ident(i), facility(f), async(a) {}
         };
+
+        /// \brief Construct stub logger.
         SyslogLogger() {}
-        explicit SyslogLogger(const Config&) {}
-        SyslogLogger(const char*,int,bool) {}
-        void log(const LogRecord&, const std::string&) override {}
-        std::string get_string_param(const LoggerParam&) const override { return {}; }
-        int64_t get_int_param(const LoggerParam&) const override { return 0; }
-        double get_float_param(const LoggerParam&) const override { return 0.0; }
-        void set_log_level(LogLevel) override {}
+
+        /// \brief Construct with configuration.
+        /// \param c Ignored configuration.
+        explicit SyslogLogger(const Config& c) { (void)c; }
+
+        /// \brief Construct with parameters.
+        /// \param ident Ignored identifier.
+        /// \param facility Ignored facility.
+        /// \param async Ignored flag.
+        SyslogLogger(const char* ident,int facility,bool async) { (void)ident; (void)facility; (void)async; }
+
+        /// \brief Ignore log request.
+        /// \param rec Log metadata.
+        /// \param msg Message text.
+        void log(const LogRecord& rec, const std::string& msg) override { (void)rec; (void)msg; }
+
+        /// \brief Return empty string parameter.
+        /// \param param Parameter identifier.
+        /// \return Empty string.
+        std::string get_string_param(const LoggerParam& param) const override { (void)param; return {}; }
+
+        /// \brief Return zero integer parameter.
+        /// \param param Parameter identifier.
+        /// \return Zero.
+        int64_t get_int_param(const LoggerParam& param) const override { (void)param; return 0; }
+
+        /// \brief Return zero float parameter.
+        /// \param param Parameter identifier.
+        /// \return Zero.
+        double get_float_param(const LoggerParam& param) const override { (void)param; return 0.0; }
+
+        /// \brief Ignore level change.
+        /// \param l Desired level.
+        void set_log_level(LogLevel l) override { (void)l; }
+
+        /// \brief Return default log level.
+        /// \return LogLevel::LOG_LVL_TRACE.
         LogLevel get_log_level() const override { return LogLevel::LOG_LVL_TRACE; }
+
+        /// \brief No-op wait.
         void wait() override {}
     };
 #   endif

--- a/include/logit_cpp/logit/loggers/SystemLogger.hpp
+++ b/include/logit_cpp/logit/loggers/SystemLogger.hpp
@@ -2,10 +2,15 @@
 #include "SyslogLogger.hpp"
 #include "EventLogLogger.hpp"
 
+/// \file SystemLogger.hpp
+/// \brief Defines alias to platform system logger.
+
 namespace logit {
 #   if defined(_WIN32)
+    /// \brief Windows system logger alias.
     using SystemLogger = EventLogLogger;
 #   else
+    /// \brief POSIX system logger alias.
     using SystemLogger = SyslogLogger;
 #   endif
 }

--- a/include/logit_cpp/logit/utils/tag_utils.hpp
+++ b/include/logit_cpp/logit/utils/tag_utils.hpp
@@ -7,24 +7,43 @@
 #include <initializer_list>
 #include <utility>
 
+/// \file tag_utils.hpp
+/// \brief Helpers for log tag formatting.
+
 namespace logit { namespace detail {
 
+    /// \brief Convert value to string via stream insertion.
+    /// \tparam T Value type supporting operator<<.
+    /// \param v Value to convert.
+    /// \return String representation.
     template <typename T>
     inline std::string to_string_any(const T& v) {
         std::ostringstream oss;
-        oss << v;                // работает для int, std::string, const char*, и т.д.
+        oss << v;
         return oss.str();
     }
 
+    /// \brief Create tag from string key and value.
+    /// \param key Tag name.
+    /// \param value Tag value.
+    /// \return Key/value pair.
     inline std::pair<std::string,std::string> make_tag(std::string key, std::string value) {
         return { std::move(key), std::move(value) };
     }
 
+    /// \brief Create tag from C-string key and arbitrary value.
+    /// \tparam V Value type convertible to string.
+    /// \param key Tag name.
+    /// \param v Tag value.
+    /// \return Key/value pair.
     template <typename V>
     inline std::pair<std::string,std::string> make_tag(const char* key, const V& v) {
         return { std::string(key), to_string_any(v) };
     }
 
+    /// \brief Format tag list into a single string.
+    /// \param tags Tags to format.
+    /// \return Serialized tag string.
     inline std::string format_tags(std::initializer_list<std::pair<std::string,std::string>> tags) {
         if (tags.size() == 0) return {};
         std::ostringstream oss;


### PR DESCRIPTION
## Summary
- document token concatenation macros
- add detailed Doxygen for log tag utilities and system loggers
- clarify compression worker and task executor internals

## Testing
- `cmake -S . -B build` *(fails: TimeShield not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79484c200832cad8b75a1fa9cf76c