### PR TITLE
docs: document new macros and loggers

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -35,10 +35,11 @@ if (LOGIT_IS_LOGGER_ENABLED(1)) {
 \endcode
 
 \par Task Executor Configuration
-Use `LOGIT_QUEUE_DROP` or `LOGIT_QUEUE_BLOCK` with `LOGIT_SET_QUEUE_POLICY`.
+Use `LOGIT_QUEUE_DROP_NEWEST`, `LOGIT_QUEUE_DROP_OLDEST`, or `LOGIT_QUEUE_BLOCK`
+with `LOGIT_SET_QUEUE_POLICY`.
 \code
 LOGIT_SET_MAX_QUEUE(64); // Limit queue size
-LOGIT_SET_QUEUE_POLICY(LOGIT_QUEUE_DROP); // Drop tasks when full
+LOGIT_SET_QUEUE_POLICY(LOGIT_QUEUE_DROP_OLDEST); // Drop oldest task when full
 \endcode
 */
 
@@ -72,4 +73,7 @@ log messages are processed and stored:
 - \b ConsoleLogger: Outputs logs to the console with optional color coding.
 - \b FileLogger: Logs messages to files with date-based rotation and old file deletion.
 - \b UniqueFileLogger: Writes each log message to a unique file with automatic cleanup.
+- \b SyslogLogger: Sends log messages to the POSIX syslog service.
+- \b EventLogLogger: Writes logs to the Windows Event Log.
+- \b SystemLogger: Alias that maps to the platform's system logger.
 */

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -46,18 +46,29 @@ LOGIT_PRINT_INFO("TimePoint example: ", now);
 
 \subsection multiple_backends Support for Multiple Backends
 
-Easily configure loggers for output to the console and files. Optionally, add support for sending messages to servers or databases by creating custom backends.
+Easily configure loggers for output to the console, files, or system logging facilities. Optionally, add support for sending messages to servers or databases by creating custom backends.
 
 \code{.cpp}
-// Adding three backends: console, file, and unique file loggers
+// Adding several backends: console, file, unique file and system loggers
 LOGIT_ADD_CONSOLE_DEFAULT();
 LOGIT_ADD_FILE_LOGGER_DEFAULT();
 LOGIT_ADD_UNIQUE_FILE_LOGGER_DEFAULT_SINGLE_MODE();
+LOGIT_ADD_SYSLOG_DEFAULT();
+LOGIT_ADD_EVENT_LOG_DEFAULT();
 \endcode
 
 \subsection async_logging Asynchronous Logging
 
 Improve application performance with asynchronous logging. All loggers handle messages in a separate thread by default.
+
+\subsection buffer_modes Queue Buffer Modes
+
+Control how the asynchronous queue behaves when full by setting a queue policy.
+\code{.cpp}
+LOGIT_SET_MAX_QUEUE(64);
+LOGIT_SET_QUEUE_POLICY(LOGIT_QUEUE_BLOCK); // Block when full
+\endcode
+Available policies: `LOGIT_QUEUE_DROP_NEWEST`, `LOGIT_QUEUE_DROP_OLDEST`, `LOGIT_QUEUE_BLOCK`.
 
 \subsection stream_logging Stream-Based Logging
 


### PR DESCRIPTION
## Summary
- document queue policy macros for buffering control
- add syslog, event log and system logger descriptions
- show system logger macros and queue policy example on main page

## Testing
- `doxygen Doxyfile` (errors: Style sheet '.github/doxygen-awesome-css/doxygen-awesome.css' specified by HTML_EXTRA_STYLESHEET does not exist!, epstopdf not found)
- `cmake -S . -B build`
- `cmake --build build` (fails: interrupt during build, see logs)


------
https://chatgpt.com/codex/tasks/task_e_68c79659d750832c9cdc2698d64b346b