### PR TITLE
feat: add CrashLogger alias header

### DIFF
--- a/include/logit_cpp/logit/loggers.hpp
+++ b/include/logit_cpp/logit/loggers.hpp
@@ -13,5 +13,6 @@
 #include "loggers/SyslogLogger.hpp"
 #include "loggers/EventLogLogger.hpp"
 #include "loggers/SystemLogger.hpp"
+#include "loggers/CrashLogger.hpp"
 
 #endif // _LOGIT_LOGGERS_HPP_INCLUDED

--- a/include/logit_cpp/logit/loggers/CrashLogger.hpp
+++ b/include/logit_cpp/logit/loggers/CrashLogger.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef LOGIT_CRASH_LOGGER_HPP_INCLUDED
+#define LOGIT_CRASH_LOGGER_HPP_INCLUDED
+
+/// \\file CrashLogger.hpp
+/// \\brief Platform-specific crash logger alias.
+
+#include "CrashPosixLogger.hpp"
+#include "CrashWindowsLogger.hpp"
+
+namespace logit {
+
+#if defined(_WIN32)
+    using CrashLogger = CrashWindowsLogger;
+#else
+    using CrashLogger = CrashPosixLogger;
+#endif
+
+} // namespace logit
+
+#endif // LOGIT_CRASH_LOGGER_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- add a CrashLogger alias header that selects the platform implementation
- expose the CrashLogger header through the aggregated loggers include

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c88d5f9460832cbc029c997e41a537