### PR TITLE
feat(config): add task executor ring capacity macro

### DIFF
--- a/include/logit_cpp/logit/config.hpp
+++ b/include/logit_cpp/logit/config.hpp
@@ -168,6 +168,17 @@
 
 /// \}
 
+/// \name Task executor settings
+/// Configuration options for the task executor implementation.
+/// \{
+
+/// \brief Default capacity for the task executor ring buffer when unlimited is requested.
+#ifndef LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY
+#define LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY 1024
+#endif
+
+/// \}
+
 
 /// \}
 

--- a/include/logit_cpp/logit/detail/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/detail/TaskExecutor.hpp
@@ -5,6 +5,8 @@
 /// \file TaskExecutor.hpp
 /// \brief Defines the TaskExecutor class, which manages task execution in a separate thread.
 
+#include "../config.hpp"
+
 #include <functional>
 #include <atomic>
 #if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
@@ -346,7 +348,7 @@ namespace logit { namespace detail {
         std::atomic<std::size_t> m_dropped_tasks;         ///< Number of discarded tasks due to overflow.
         std::atomic<std::size_t> m_active_tasks;          ///< Number of tasks currently running.
 
-        const std::size_t m_default_ring_cap = 1024;      ///< Default capacity when unlimited requested.
+        const std::size_t m_default_ring_cap = LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY; ///< Default capacity when unlimited requested.
         MpscRingAny<std::function<void()>> m_mpsc_queue;  ///< Lock-free bounded MPSC ring.
 
 #ifdef LOGIT_ENABLE_DROP_OLDEST_SLOWPATH


### PR DESCRIPTION
## Summary
- add configuration macro for the task executor ring buffer capacity
- use the new macro inside the task executor implementation

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8a165ff4c832ca8b26002477a4162