### PR TITLE
Move LogStream header under detail directory

### DIFF
--- a/include/logit_cpp/logit.hpp
+++ b/include/logit_cpp/logit.hpp
@@ -9,7 +9,7 @@
 #include "logit/enums.hpp"
 #include "logit/utils.hpp"
 #include "logit/Logger.hpp"
-#include "logit/LogStream.hpp"
+#include "logit/detail/LogStream.hpp"
 #include "logit/detail/ScopeTimer.hpp"
 #include "logit/log_macros.hpp"
 #include "logit/formatter.hpp"

--- a/include/logit_cpp/logit/detail/LogStream.hpp
+++ b/include/logit_cpp/logit/detail/LogStream.hpp
@@ -1,13 +1,13 @@
 #pragma once
-#ifndef _LOGIT_LOG_STREAM_HPP_INCLUDED
-#define _LOGIT_LOG_STREAM_HPP_INCLUDED
+#ifndef _LOGIT_DETAIL_LOG_STREAM_HPP_INCLUDED
+#define _LOGIT_DETAIL_LOG_STREAM_HPP_INCLUDED
 
 /// \file LogStream.hpp
 /// \brief Defines the LogStream class for stream-like logging functionality.
 
 #include <sstream>
-#include "Logger.hpp"
-#include "utils/path_utils.hpp"
+#include "../Logger.hpp"
+#include "../utils/path_utils.hpp"
 
 namespace logit {
 
@@ -78,4 +78,4 @@ namespace logit {
 
 } // namespace logit
 
-#endif // _LOGIT_LOG_STREAM_HPP_INCLUDED
+#endif // _LOGIT_DETAIL_LOG_STREAM_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- move `LogStream.hpp` into `include/logit_cpp/logit/detail` and adjust its include guard and relative dependencies
- update the public umbrella header to include the new detail path

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68c9d4c5e624832cbade0bc7a12020b3