### PR TITLE
feat: add TaskExecutor drain budget macro

### DIFF
--- a/docs/TaskExecutor.md
+++ b/docs/TaskExecutor.md
@@ -198,10 +198,11 @@ const auto lost = LOGIT_GET_DROPPED_TASKS();
 * `QueuePolicy::Block` limits the number of in-flight tasks tracked by
   `m_active_tasks`. Use it to introduce producer-side backpressure when the
   downstream sinks are expensive.
-* The worker drains up to 2048 tasks per iteration when the ring is enabled.
-  Increase this "budget" in `TaskExecutor::worker_function()` if your workload
-  generates extremely large bursts and the worker sleeps too often. Reducing it
-  can lower per-iteration latency for latency-sensitive applications.
+* The worker drains up to `LOGIT_TASK_EXECUTOR_DRAIN_BUDGET` tasks per iteration
+  when the ring is enabled. Increase this "budget" in
+  `TaskExecutor::worker_function()` if your workload generates extremely large
+  bursts and the worker sleeps too often. Reducing it can lower per-iteration
+  latency for latency-sensitive applications.
 * Adjust `LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY` at compile time to select a
   different default capacity when `LOGIT_USE_MPSC_RING` is active.
 * Monitor `dropped_tasks()` during load testing to verify that the chosen policy

--- a/include/logit_cpp/logit/config.hpp
+++ b/include/logit_cpp/logit/config.hpp
@@ -202,6 +202,14 @@
 /// Configuration options for the task executor implementation.
 /// \{
 
+/// \brief Maximum number of tasks drained per worker iteration in ring-buffer builds.
+/// If `LOGIT_TASK_EXECUTOR_DRAIN_BUDGET` is not defined, the worker drains up to 2048
+/// tasks before yielding. Increase the value to process larger bursts before sleeping,
+/// or reduce it to prioritise lower per-iteration latency.
+#ifndef LOGIT_TASK_EXECUTOR_DRAIN_BUDGET
+#define LOGIT_TASK_EXECUTOR_DRAIN_BUDGET 2048
+#endif
+
 /// \brief Default capacity for the task executor ring buffer when unlimited is requested.
 #ifndef LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY
 #define LOGIT_TASK_EXECUTOR_DEFAULT_RING_CAPACITY 1024

--- a/include/logit_cpp/logit/detail/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/detail/TaskExecutor.hpp
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <atomic>
+#include "logit/config.hpp"
 #if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
   #include <deque>
   #include <mutex>
@@ -439,7 +440,7 @@ namespace logit { namespace detail {
                 bool drained_any = false;
                 std::function<void()> task;
     
-                int budget = 2048;
+                int budget = LOGIT_TASK_EXECUTOR_DRAIN_BUDGET;
                 while (budget-- && m_mpsc_queue.try_pop(task)) {
                     drained_any = true;
                     m_active_tasks.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
## Summary
- add the LOGIT_TASK_EXECUTOR_DRAIN_BUDGET configuration macro with documentation
- use the new macro inside TaskExecutor and include the configuration header
- reference the macro in the TaskExecutor design notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6db3c858832c9671fd340ff01a9a