### PR TITLE
feat: make TaskExecutor block wait configurable

### DIFF
--- a/docs/TaskExecutor.md
+++ b/docs/TaskExecutor.md
@@ -49,7 +49,9 @@ lifetime guarantees that logger integrations rely on.
   * Uses `m_active_tasks` to count in-flight work. If the counter reaches the
     limit, producers wait. The non-MPSC build waits on
     `m_queue_condition`. The MPSC build parks on `m_cv` with short sleeps while
-    the worker drains tasks. This policy avoids loss at the expense of
+    the worker drains tasks. The sleep interval defaults to
+    `LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC` microseconds (200 by default) and can
+    be overridden at compile time. This policy avoids loss at the expense of
     producer-side backpressure.
 * `DropNewest`
   * Non-MPSC: the incoming task is discarded when the deque is full.

--- a/include/logit_cpp/logit/Logger.hpp
+++ b/include/logit_cpp/logit/Logger.hpp
@@ -5,6 +5,7 @@
 /// \file Logger.hpp
 /// \brief Defines the Logger class for managing multiple loggers and formatters.
 
+#include "config.hpp"
 #include "loggers/ILogger.hpp"
 #include "formatter.hpp"
 #include "detail/TaskExecutor.hpp"

--- a/include/logit_cpp/logit/config.hpp
+++ b/include/logit_cpp/logit/config.hpp
@@ -22,6 +22,15 @@
     #define LOGIT_DEFAULT_COLOR logit::TextColor::LightGray
 #endif
 
+/// \brief Defines the sleep duration (in microseconds) used by TaskExecutor when blocking producers.
+///
+/// When `QueuePolicy::Block` is active, the TaskExecutor periodically waits for
+/// capacity to become available. Override this value to tweak the polling
+/// cadence in builds where the default wait is not appropriate.
+#ifndef LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC
+    #define LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC 200
+#endif
+
 /// \name Log Level Colors
 /// Default colors for each log level.
 /// \{

--- a/include/logit_cpp/logit/detail/TaskExecutor.hpp
+++ b/include/logit_cpp/logit/detail/TaskExecutor.hpp
@@ -242,7 +242,7 @@ namespace logit { namespace detail {
                     m_active_tasks.load(std::memory_order_relaxed) >= m_max_queue_size)
                 {
                     std::unique_lock<std::mutex> lk(m_cv_mutex);
-                    m_cv.wait_for(lk, std::chrono::microseconds(200));
+                    m_cv.wait_for(lk, std::chrono::microseconds(LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC));
                     continue;
                 }
     
@@ -266,7 +266,7 @@ namespace logit { namespace detail {
     
                     case QueuePolicy::Block: {
                         std::unique_lock<std::mutex> lk(m_cv_mutex);
-                        m_cv.wait_for(lk, std::chrono::microseconds(200));
+                        m_cv.wait_for(lk, std::chrono::microseconds(LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC));
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- add the LOGIT_TASK_EXECUTOR_BLOCK_WAIT_USEC configuration macro and expose it to TaskExecutor
- replace the hard-coded blocking wait with the macro and document the override in the TaskExecutor notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb70d273a4832cbbcf2fe2f4739cdd