### PR TITLE
fix(bench): add timestamped logs and watchdog progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: cmake --build build-bench --target logit_bench
       - name: Run latency benchmarks
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/stable') }}
+        timeout-minutes: 20
+        env:
+          LOGIT_BENCH_TIMEOUT_SEC: 900
+          LOGIT_BENCH_TOTAL: 20000
+          LOGIT_BENCH_WARMUP: 2000
         run: ./build-bench/logit_bench
       - name: Configure consumer project
         run: cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install -DCMAKE_CXX_STANDARD=${{ matrix.std }}

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -13,6 +13,16 @@ target_include_directories(logit_bench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_features(logit_bench PRIVATE cxx_std_17)
 
+set_target_properties(logit_bench PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+foreach(config IN ITEMS DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+    set_target_properties(logit_bench PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY_${config} ${CMAKE_BINARY_DIR}
+    )
+endforeach()
+
 target_link_libraries(logit_bench PRIVATE log-it-cpp::log-it-cpp)
 
 if(LOGIT_BENCH_WITH_SPDLOG)

--- a/bench/logit_bench.cpp
+++ b/bench/logit_bench.cpp
@@ -1,17 +1,21 @@
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <ctime>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
+#include <sstream>
 
 #include "LatencyRecorder.hpp"
 #include "Scenario.hpp"
@@ -23,6 +27,8 @@
 
 namespace logit_bench {
 namespace {
+
+std::atomic<std::uint64_t>* g_watchdog_progress = nullptr;
 
 std::string make_message(std::size_t bytes, std::size_t index) {
     if (bytes == 0) return {};
@@ -39,6 +45,44 @@ std::size_t get_env_size_t(const char* name, std::size_t def) {
         }
     }
     return def;
+}
+
+std::uint64_t steady_now_ns() {
+    const auto now_tp = std::chrono::steady_clock::now().time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now_tp).count();
+}
+
+std::string format_timestamp() {
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &time);
+#else
+    localtime_r(&time, &tm);
+#endif
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now.time_since_epoch()) % 1000;
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S")
+        << '.' << std::setw(3) << std::setfill('0') << ms.count();
+    return oss.str();
+}
+
+void touch_watchdog() {
+    if (g_watchdog_progress) {
+        g_watchdog_progress->store(steady_now_ns(), std::memory_order_relaxed);
+    }
+}
+
+void log_info(const std::string& message) {
+    std::cout << "[logit_bench " << format_timestamp() << "] " << message << std::endl;
+    touch_watchdog();
+}
+
+void log_error(const std::string& message) {
+    std::cerr << "[logit_bench " << format_timestamp() << "] " << message << std::endl;
+    touch_watchdog();
 }
 
 /**
@@ -130,10 +174,48 @@ ScenarioResult execute_scenario(
     adapter.prepare(scenario, recorder);
 
     // Warm-up (no recording, no duration).
+    {
+        std::ostringstream oss;
+        oss << "Warm-up start lib=" << adapter.library_name()
+            << " async=" << (scenario.async ? '1' : '0')
+            << " sink=" << sink_name(scenario.sink)
+            << " producers=" << scenario.producers
+            << " bytes=" << scenario.message_bytes
+            << " total=" << warmup_messages;
+        log_info(oss.str());
+    }
     run_workload(adapter, recorder, scenario, warmup_messages, false, false);
+    {
+        std::ostringstream oss;
+        oss << "Warm-up completed lib=" << adapter.library_name()
+            << " async=" << (scenario.async ? '1' : '0')
+            << " sink=" << sink_name(scenario.sink)
+            << " producers=" << scenario.producers
+            << " bytes=" << scenario.message_bytes;
+        log_info(oss.str());
+    }
 
     // Measured run.
+    {
+        std::ostringstream oss;
+        oss << "Measure start lib=" << adapter.library_name()
+            << " async=" << (scenario.async ? '1' : '0')
+            << " sink=" << sink_name(scenario.sink)
+            << " producers=" << scenario.producers
+            << " bytes=" << scenario.message_bytes
+            << " total=" << scenario.total_messages;
+        log_info(oss.str());
+    }
     const auto dur = run_workload(adapter, recorder, scenario, scenario.total_messages, true, true);
+    {
+        std::ostringstream oss;
+        oss << "Measure completed lib=" << adapter.library_name()
+            << " async=" << (scenario.async ? '1' : '0')
+            << " sink=" << sink_name(scenario.sink)
+            << " producers=" << scenario.producers
+            << " bytes=" << scenario.message_bytes;
+        log_info(oss.str());
+    }
     const auto sum = recorder.finalize();
 
     double thr = 0.0;
@@ -179,17 +261,19 @@ void print_summary(
         const Scenario& scenario,
         const ScenarioResult& result)
 {
-    std::cout << library
-              << " async=" << (scenario.async ? '1' : '0')
-              << " sink=" << sink_name(scenario.sink)
-              << " producers=" << scenario.producers
-              << " bytes=" << scenario.message_bytes
-              << " total=" << scenario.total_messages
-              << " p50=" << result.summary.p50_ns
-              << "ns p99=" << result.summary.p99_ns
-              << "ns p999=" << result.summary.p999_ns
-              << "ns throughput=" << std::fixed << std::setprecision(2)
-              << result.throughput << " msg/s\n";
+    std::ostringstream oss;
+    oss << library
+        << " async=" << (scenario.async ? '1' : '0')
+        << " sink=" << sink_name(scenario.sink)
+        << " producers=" << scenario.producers
+        << " bytes=" << scenario.message_bytes
+        << " total=" << scenario.total_messages
+        << " p50=" << result.summary.p50_ns
+        << "ns p99=" << result.summary.p99_ns
+        << "ns p999=" << result.summary.p999_ns
+        << "ns throughput=" << std::fixed << std::setprecision(2)
+        << result.throughput << " msg/s";
+    log_info(oss.str());
 }
 
 } // namespace
@@ -197,6 +281,10 @@ void print_summary(
 
 int main() {
     using namespace logit_bench;
+    std::atomic<bool> watchdog_done{false};
+    std::thread watchdog;
+    std::atomic<std::uint64_t> watchdog_progress{steady_now_ns()};
+    g_watchdog_progress = &watchdog_progress;
     try {
         std::vector<std::unique_ptr<ILoggerAdapter>> adapters;
         adapters.emplace_back(std::make_unique<LogItAdapter>());
@@ -213,6 +301,24 @@ int main() {
         // Totals (can be overridden by env):
         const std::size_t total_messages  = get_env_size_t("LOGIT_BENCH_TOTAL", 200000);
         const std::size_t warmup_messages = get_env_size_t("LOGIT_BENCH_WARMUP", 4096);
+        const std::size_t timeout_seconds = get_env_size_t("LOGIT_BENCH_TIMEOUT_SEC", 600);
+
+        if (timeout_seconds > 0) {
+            watchdog = std::thread([timeout_seconds, &watchdog_done, &watchdog_progress]() {
+                const auto timeout = std::chrono::seconds(timeout_seconds);
+                while (!watchdog_done.load(std::memory_order_relaxed)) {
+                    const auto last_ns = watchdog_progress.load(std::memory_order_relaxed);
+                    const auto last_tp = std::chrono::steady_clock::time_point(std::chrono::nanoseconds(last_ns));
+                    if (std::chrono::steady_clock::now() - last_tp >= timeout) {
+                        log_error(std::string("Timeout reached after ") + std::to_string(timeout_seconds)
+                                  + " seconds without progress. Terminating benchmark.");
+                        std::cerr.flush();
+                        std::_Exit(124);
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                }
+            });
+        }
 
         for (auto& adapter : adapters) {
             for (bool async_mode : async_modes) {
@@ -226,6 +332,16 @@ int main() {
                             scenario.message_bytes  = msg_bytes;
                             scenario.total_messages = total_messages;
 
+                            {
+                                std::ostringstream oss;
+                                oss << "Scenario start lib=" << adapter->library_name()
+                                    << " async=" << (scenario.async ? '1' : '0')
+                                    << " sink=" << sink_name(scenario.sink)
+                                    << " producers=" << scenario.producers
+                                    << " bytes=" << scenario.message_bytes
+                                    << " total=" << scenario.total_messages;
+                                log_info(oss.str());
+                            }
                             auto result = execute_scenario(*adapter, scenario, warmup_messages);
                             append_csv(adapter->library_name(), scenario, result.summary, result.throughput);
                             print_summary(adapter->library_name(), scenario, result);
@@ -234,9 +350,15 @@ int main() {
                 }
             }
         }
+        watchdog_done.store(true, std::memory_order_relaxed);
+        if (watchdog.joinable()) watchdog.join();
     } catch (const std::exception& ex) {
-        std::cerr << "Benchmark failed: " << ex.what() << std::endl;
+        watchdog_done.store(true, std::memory_order_relaxed);
+        if (watchdog.joinable()) watchdog.join();
+        log_error(std::string("Benchmark failed: ") + ex.what());
+        g_watchdog_progress = nullptr;
         return 1;
     }
+    g_watchdog_progress = nullptr;
     return 0;
 }


### PR DESCRIPTION
## Summary
- add timestamped logging helpers so every benchmark message includes wall-clock timing
- refresh the watchdog whenever new output is produced and trigger on inactivity instead of total runtime
- reuse the new helpers across the scenario lifecycle, summaries, and error paths for consistent logging

## Testing
- `cmake -S . -B build-bench -DLOGIT_BENCH_ENABLE=ON` *(fails: TimeShield submodule missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc92a600e8832cb8946a3024543d6d