### PR TITLE
feat(otlp): expose export counters via logger params

### DIFF
--- a/docs/OtlpHttpLogger.md
+++ b/docs/OtlpHttpLogger.md
@@ -64,6 +64,24 @@ LogIt++ -> OtlpHttpLogger -> kurlyk::HttpClient -> OpenTelemetry Collector / Lok
 
 Resource attributes are configured through `OtlpHttpLoggerConfig`, including `service.name`, `service.namespace`, `service.instance.id`, and `deployment.environment.name`.
 
+## Diagnostics
+
+`OtlpHttpLogger` exposes its internal counters through the generic logger parameter API:
+
+```cpp
+const auto dropped = LOGIT_GET_INT_PARAM(otlp_index, logit::LoggerParam::DroppedLogCount);
+const auto failed = LOGIT_GET_INT_PARAM(otlp_index, logit::LoggerParam::FailedExportCount);
+```
+
+Available diagnostic params:
+
+| Parameter | Meaning |
+| --- | --- |
+| `LoggerParam::DroppedLogCount` | Number of records dropped because the backend queue overflowed or the logger was stopping. |
+| `LoggerParam::FailedExportCount` | Number of failed OTLP export attempts. |
+
+These values are also available through `get_string_param()` and `get_float_param()`. Integer retrieval saturates at `int64_t` max if the underlying unsigned counter ever exceeds that range.
+
 ## Notes
 
 - `OtlpHttpLogger` is an outbound client/exporter, not a server.

--- a/include/logit_cpp/logit/enums.hpp
+++ b/include/logit_cpp/logit/enums.hpp
@@ -132,7 +132,39 @@ namespace logit {
             "\033[96m",   // Cyan
             "\033[97m"    // White
         };
-        return ansi_codes[static_cast<size_t>(color)];
+
+        // Convert TextColor to a string with an ANSI code
+        return ansi_codes[static_cast<int>(color)];
+    }
+
+    /// \brief Convert TextColor to a std::string (ANSI escape codes).
+    /// \param color The text color.
+    /// \return std::string representing the ANSI escape code for the color.
+    inline std::string to_string(TextColor color) {
+        return std::string(to_c_str(color));
+    }
+
+    /// \brief Get the ANSI color code associated with a log level.
+    /// \param log_level The log level.
+    /// \return ANSI escape code string representing the color for the log level.
+    inline std::string get_log_level_color(LogLevel log_level) {
+        switch (log_level) {
+            case LogLevel::LOG_LVL_TRACE:
+                return to_string(LOGIT_COLOR_TRACE);
+            case LogLevel::LOG_LVL_DEBUG:
+                return to_string(LOGIT_COLOR_DEBUG);
+            case LogLevel::LOG_LVL_INFO:
+                return to_string(LOGIT_COLOR_INFO);
+            case LogLevel::LOG_LVL_WARN:
+                return to_string(LOGIT_COLOR_WARN);
+            case LogLevel::LOG_LVL_ERROR:
+                return to_string(LOGIT_COLOR_ERROR);
+            case LogLevel::LOG_LVL_FATAL:
+                return to_string(LOGIT_COLOR_FATAL);
+            default:
+                break;
+        }
+        return to_string(LOGIT_COLOR_DEFAULT);
     }
 
 }; // namespace logit

--- a/include/logit_cpp/logit/enums.hpp
+++ b/include/logit_cpp/logit/enums.hpp
@@ -48,7 +48,9 @@ namespace logit {
         LastFileName,          ///< The name of the last file written to.
         LastFilePath,          ///< The full path of the last file written to.
         LastLogTimestamp,      ///< The timestamp of the last log.
-        TimeSinceLastLog       ///< The time elapsed since the last log in seconds.
+        TimeSinceLastLog,      ///< The time elapsed since the last log in seconds.
+        DroppedLogCount,       ///< Number of log records dropped by the backend.
+        FailedExportCount      ///< Number of failed export attempts reported by the backend.
     };
 
     /// \enum CompressType
@@ -130,39 +132,7 @@ namespace logit {
             "\033[96m",   // Cyan
             "\033[97m"    // White
         };
-
-        // Convert TextColor to a string with an ANSI code
-        return ansi_codes[static_cast<int>(color)];
-    }
-
-    /// \brief Convert TextColor to a std::string (ANSI escape codes).
-    /// \param color The text color.
-    /// \return std::string representing the ANSI escape code for the color.
-    inline std::string to_string(TextColor color) {
-        return std::string(to_c_str(color));
-    }
-
-    /// \brief Get the ANSI color code associated with a log level.
-    /// \param log_level The log level.
-    /// \return ANSI escape code string representing the color for the log level.
-    inline std::string get_log_level_color(LogLevel log_level) {
-        switch (log_level) {
-            case LogLevel::LOG_LVL_TRACE:
-                return to_string(LOGIT_COLOR_TRACE);
-            case LogLevel::LOG_LVL_DEBUG:
-                return to_string(LOGIT_COLOR_DEBUG);
-            case LogLevel::LOG_LVL_INFO:
-                return to_string(LOGIT_COLOR_INFO);
-            case LogLevel::LOG_LVL_WARN:
-                return to_string(LOGIT_COLOR_WARN);
-            case LogLevel::LOG_LVL_ERROR:
-                return to_string(LOGIT_COLOR_ERROR);
-            case LogLevel::LOG_LVL_FATAL:
-                return to_string(LOGIT_COLOR_FATAL);
-            default:
-                break;
-        }
-        return to_string(LOGIT_COLOR_DEFAULT);
+        return ansi_codes[static_cast<size_t>(color)];
     }
 
 }; // namespace logit

--- a/include/logit_cpp/logit/loggers/OtlpHttpLogger.hpp
+++ b/include/logit_cpp/logit/loggers/OtlpHttpLogger.hpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <deque>
 #include <future>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -126,6 +127,8 @@ namespace logit {
             switch (param) {
             case LoggerParam::LastLogTimestamp: return std::to_string(get_last_log_ts());
             case LoggerParam::TimeSinceLastLog: return std::to_string(get_time_since_last_log());
+            case LoggerParam::DroppedLogCount: return std::to_string(dropped_count());
+            case LoggerParam::FailedExportCount: return std::to_string(failed_export_count());
             default:
                 break;
             }
@@ -139,6 +142,8 @@ namespace logit {
             switch (param) {
             case LoggerParam::LastLogTimestamp: return get_last_log_ts();
             case LoggerParam::TimeSinceLastLog: return get_time_since_last_log();
+            case LoggerParam::DroppedLogCount: return counter_to_int64(dropped_count());
+            case LoggerParam::FailedExportCount: return counter_to_int64(failed_export_count());
             default:
                 break;
             }
@@ -147,13 +152,17 @@ namespace logit {
 
         /// \brief Retrieves a floating-point parameter from the logger.
         /// \param param Parameter to retrieve.
-        /// \return Parameter value in seconds, or 0.0 when unsupported.
+        /// \return Parameter value in seconds for time params, raw count for counter params, or 0.0 when unsupported.
         double get_float_param(const LoggerParam& param) const override {
             switch (param) {
             case LoggerParam::LastLogTimestamp:
                 return static_cast<double>(get_last_log_ts()) / 1000.0;
             case LoggerParam::TimeSinceLastLog:
                 return static_cast<double>(get_time_since_last_log()) / 1000.0;
+            case LoggerParam::DroppedLogCount:
+                return static_cast<double>(dropped_count());
+            case LoggerParam::FailedExportCount:
+                return static_cast<double>(failed_export_count());
             default:
                 break;
             }
@@ -316,6 +325,14 @@ namespace logit {
             }
             const int64_t now = LOGIT_CURRENT_TIMESTAMP_MS();
             return now > last ? now - last : 0;
+        }
+
+        /// \brief Converts unsigned counter value to int64_t with saturation.
+        /// \param value Counter value.
+        /// \return Counter value clamped to int64_t max.
+        static int64_t counter_to_int64(uint64_t value) {
+            const uint64_t max_value = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
+            return value > max_value ? (std::numeric_limits<int64_t>::max)() : static_cast<int64_t>(value);
         }
     };
 


### PR DESCRIPTION
## Summary

- Add generic diagnostic logger params:
  - `LoggerParam::DroppedLogCount`
  - `LoggerParam::FailedExportCount`
- Expose `OtlpHttpLogger` dropped-record and failed-export counters through `get_string_param()`, `get_int_param()`, and `get_float_param()`.
- Use saturating conversion when exposing unsigned counters through the existing `int64_t` param API.
- Document OTLP diagnostics usage.

## Notes

- This PR is intentionally small and only extends the generic parameter API for existing OTLP counters.
- No direct logging is added inside OTLP error paths, so recursive logging loops remain avoided.

## Testing

Not run in this environment.