### PR TITLE
test(logging): drain mixed-mode probe logger

### DIFF
--- a/tests/per_logger_mixed_mode_test.cpp
+++ b/tests/per_logger_mixed_mode_test.cpp
@@ -28,7 +28,7 @@ public:
     }
 
     ~CountingLogger() override {
-        if (m_executor) m_executor->shutdown();
+        shutdown();
     }
 
     void log(const LogRecord& record, const std::string& message) override {
@@ -54,6 +54,11 @@ public:
         if (!m_cfg.async) return;
         if (m_executor) m_executor->wait();
         else logit::detail::TaskExecutor::get_instance().wait();
+    }
+
+    void shutdown() override {
+        wait();
+        if (m_executor) m_executor->shutdown();
     }
 
     std::size_t count() const { return m_count.load(std::memory_order_relaxed); }


### PR DESCRIPTION
## Summary
- Fix `per_logger_mixed_mode_test` probe logger teardown so global-executor tasks cannot outlive the stack logger they capture.
- Align the test probe lifecycle with built-in async logger behavior by calling `shutdown()` from the destructor.

## Cause
The failed macOS main run printed `PASS: mixed_mode_drain`, `PASS: mixed_mode_shutdown`, and `2 passed, 0 failed`, but CTest still marked the process failed. `LastTest.log` points to a post-output process failure: `CountingLogger` only shut down its dedicated executor in the destructor, while global-executor tasks captured `this` and could run after the stack object was destroyed.

## Tests
- `cmake --build build-codex-fix --target per_logger_mixed_mode_test`
- `ctest --test-dir build-codex-fix -R per_logger_mixed_mode_test --output-on-failure --repeat until-fail:100`
- `cmake --build build-codex-fix --target per_logger_isolation_test`
- `ctest --test-dir build-codex-fix -R "per_logger_isolation_test|per_logger_mixed_mode_test" --output-on-failure --repeat until-fail:50`
- GitHub Actions CI #308: passed after rerunning checkout-failed jobs