### PR TITLE
fix(mdbx): restore optional build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,29 @@ jobs:
             build/Testing/Temporary/LastTest.log
           if-no-files-found: ignore
 
+  linux-mdbx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: git submodule update --init --recursive
+      - name: Configure MDBX
+        run: cmake -S . -B build-mdbx -DLOGIT_CPP_BUILD_TESTS=ON -DLOGIT_CPP_BUILD_EXAMPLES=ON -DLOGIT_WITH_MDBX=ON -DLOGIT_USE_SUBMODULES=ON -DCMAKE_CXX_STANDARD=17
+      - name: Build MDBX
+        run: cmake --build build-mdbx
+      - name: Test MDBX
+        run: ctest --test-dir build-mdbx --output-on-failure -R mdbx_logger_test
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-mdbx
+          path: |
+            build-mdbx/CMakeFiles/CMakeOutput.log
+            build-mdbx/Testing/Temporary/LastTest.log
+          if-no-files-found: ignore
+
   windows:
     runs-on: windows-latest
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,17 @@ option(LOGIT_USE_MPSC_RING "Enable lock-free TaskExecutor queue" ON)
 option(LOGIT_ENABLE_DROP_OLDEST_SLOWPATH "Enable TaskExecutor DropOldest slow-path" ON)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-    if(LOGIT_WITH_OTLP OR LOGIT_WITH_PROMETHEUS_SERVER)
+    if(LOGIT_WITH_OTLP OR LOGIT_WITH_PROMETHEUS_SERVER OR LOGIT_WITH_MDBX)
         set(CMAKE_CXX_STANDARD 17)
     else()
         set(CMAKE_CXX_STANDARD 11)
     endif()
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(LOGIT_WITH_MDBX AND CMAKE_CXX_STANDARD LESS 17)
+    message(FATAL_ERROR "LOGIT_WITH_MDBX requires C++17 or newer.")
+endif()
 
 # Dependency: TimeShield
 find_package(TimeShield 1.0.6 QUIET CONFIG)

--- a/examples/example_logit_mdbx_logger.cpp
+++ b/examples/example_logit_mdbx_logger.cpp
@@ -63,7 +63,7 @@ int main() {
         ("[%l] %v"));
 
     // The MDBX logger is now the last added backend; its index is:
-    const int mdbx_index = static_cast<int>(logit::Logger::get_instance().get_all_strategy_snapshots().size()) - 1;
+    const int mdbx_index = static_cast<int>(logit::Logger::get_instance().logger_count()) - 1;
 
     // Also add a console logger for live observation (optional).
     LOGIT_ADD_CONSOLE_DEFAULT();

--- a/include/logit_cpp/logit/Logger.hpp
+++ b/include/logit_cpp/logit/Logger.hpp
@@ -407,10 +407,19 @@ namespace logit {
 
         /// \brief Retrieves a typed backend pointer from a logger by index.
         template <typename LoggerT>
-        LoggerT* get_logger_as(int logger_index) const {
+        LoggerT* get_logger_as(int logger_index) {
             auto strategy = get_strategy_snapshot(logger_index);
             return (strategy && strategy->logger)
                 ? dynamic_cast<LoggerT*>(strategy->logger.get())
+                : nullptr;
+        }
+
+        /// \brief Retrieves a typed backend pointer from a logger by index.
+        template <typename LoggerT>
+        const LoggerT* get_logger_as(int logger_index) const {
+            auto strategy = get_strategy_snapshot(logger_index);
+            return (strategy && strategy->logger)
+                ? dynamic_cast<const LoggerT*>(strategy->logger.get())
                 : nullptr;
         }
 

--- a/include/logit_cpp/logit/Logger.hpp
+++ b/include/logit_cpp/logit/Logger.hpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <sstream>
 #include <atomic>
+#include <cstddef>
 
 #if __cplusplus >= 201703L
 #include <shared_mutex>
@@ -396,6 +397,21 @@ namespace logit {
                 if (!strategy) continue;
                 strategy->logger->wait();
             }
+        }
+
+        /// \brief Returns the number of registered logger strategies.
+        std::size_t logger_count() const {
+            LoggerReadLock lock(m_loggers_mx);
+            return m_loggers.size();
+        }
+
+        /// \brief Retrieves a typed backend pointer from a logger by index.
+        template <typename LoggerT>
+        LoggerT* get_logger_as(int logger_index) const {
+            auto strategy = get_strategy_snapshot(logger_index);
+            return (strategy && strategy->logger)
+                ? dynamic_cast<LoggerT*>(strategy->logger.get())
+                : nullptr;
         }
 
         /// \brief Shuts down logger system.

--- a/include/logit_cpp/logit/log_macros.hpp
+++ b/include/logit_cpp/logit/log_macros.hpp
@@ -2910,12 +2910,7 @@ static_assert(LOGIT_LEVEL_FATAL == static_cast<int>(logit::LogLevel::LOG_LVL_FAT
 /// \param logger_type Concrete logger type (e.g., logit::MdbxLogger).
 /// \return Pointer to the backend, or nullptr if index/type does not match.
 #define LOGIT_GET_LOGGER_AS(logger_index, logger_type) \
-    ([](int _logit_logger_index) -> logger_type* { \
-        auto _logit_strategy = ::logit::Logger::get_instance().get_strategy_snapshot(_logit_logger_index); \
-        return (_logit_strategy && _logit_strategy->logger) \
-            ? dynamic_cast<logger_type*>(_logit_strategy->logger.get()) \
-            : nullptr; \
-    }((logger_index)))
+    (::logit::Logger::get_instance().get_logger_as<logger_type>((logger_index)))
 
 /// \brief Executes a code block when the logger backend has the requested type.
 /// \param logger_index Index of logger.

--- a/include/logit_cpp/logit/loggers/MdbxLogger.hpp
+++ b/include/logit_cpp/logit/loggers/MdbxLogger.hpp
@@ -384,6 +384,9 @@ namespace logit {
             int64_t end_time_ms = 0;
             uint64_t process_id = 0;
             uint32_t schema_version = 1;
+
+            std::vector<uint8_t> to_bytes() const;
+            static Session from_bytes(const void* data, size_t size);
         };
 
         struct Record {
@@ -396,12 +399,18 @@ namespace logit {
             std::string file;
             std::string function;
             int line = 0;
+
+            std::vector<uint8_t> to_bytes() const;
+            static Record from_bytes(const void* data, size_t size);
         };
 
         struct Payload {
             uint64_t payload_id = 0;
             MdbxPayloadCompression compression = MdbxPayloadCompression::None;
             std::string data;
+
+            std::vector<uint8_t> to_bytes() const;
+            static Payload from_bytes(const void* data, size_t size);
         };
 
         typedef mdbxc::KeyValueTable<uint64_t, Session> SessionTable;
@@ -904,6 +913,30 @@ namespace logit {
             return value > max_value ? (std::numeric_limits<int64_t>::max)() : static_cast<int64_t>(value);
         }
     };
+
+    inline std::vector<uint8_t> MdbxLogger::Session::to_bytes() const {
+        return MdbxLogger::serialize_session(*this);
+    }
+
+    inline MdbxLogger::Session MdbxLogger::Session::from_bytes(const void* data, size_t size) {
+        return MdbxLogger::deserialize_session(data, size);
+    }
+
+    inline std::vector<uint8_t> MdbxLogger::Record::to_bytes() const {
+        return MdbxLogger::serialize_record(*this);
+    }
+
+    inline MdbxLogger::Record MdbxLogger::Record::from_bytes(const void* data, size_t size) {
+        return MdbxLogger::deserialize_record(data, size);
+    }
+
+    inline std::vector<uint8_t> MdbxLogger::Payload::to_bytes() const {
+        return MdbxLogger::serialize_payload(*this);
+    }
+
+    inline MdbxLogger::Payload MdbxLogger::Payload::from_bytes(const void* data, size_t size) {
+        return MdbxLogger::deserialize_payload(data, size);
+    }
 
 } // namespace logit
 


### PR DESCRIPTION
## Summary
- add public Logger backend accessors used by typed logger macros and the MDBX example
- add mdbx-containers to_bytes/from_bytes support for MdbxLogger value types
- add explicit C++17 guard and MDBX CI job

## Replacement PR
This replaces #113. The previous PR was opened from feat/mdbx-logger after main already contained the squashed MDBX feature work, so GitHub showed the old MDBX diff again and reported merge conflicts. This branch was recreated from current origin/main and contains only the incremental fix.

## Verification
- cmake -S . -B build-mdbx-clean -G "MinGW Makefiles" -DLOGIT_CPP_BUILD_TESTS=ON -DLOGIT_CPP_BUILD_EXAMPLES=ON -DLOGIT_WITH_MDBX=ON -DLOGIT_USE_SUBMODULES=ON -DCMAKE_CXX_STANDARD=17
- cmake --build build-mdbx-clean
- ctest --test-dir build-mdbx-clean --output-on-failure -R mdbx_logger_test
- cmake -S . -B build-default-clean -G "MinGW Makefiles" -DLOGIT_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=17
- cmake --build build-default-clean
- ctest --test-dir build-default-clean --output-on-failure --quiet
- git diff --check origin/main...HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)