### PR TITLE
feat(mdbx): add read result API

### DIFF
--- a/guides/cpp_style.md
+++ b/guides/cpp_style.md
@@ -52,3 +52,13 @@
 - Enum values use `CamelCase`.
 - Mark non-inheritable classes with `final`.
 - Use `override` for overridden virtual methods.
+
+## Semantic values
+
+- Avoid magic numbers: do not leave unnamed numbers such as `0xD0` when the meaning is not obvious.
+- Avoid magic literals: apply the same rule to strings, bytes, characters, regexes, paths, and flags.
+- Use intention-revealing names: the name should explain the value role, such as `invalid_utf8_leading_byte` instead of `byte`.
+- Make invalid and edge cases explicit: test data for errors should state which error it validates.
+- Prefer named constants for semantic values: if a value has domain meaning, give it a name.
+- Separate data meaning from representation: `0xD0` is representation; truncated UTF-8 leading byte is meaning.
+- Follow the Principle of Least Astonishment: readers should not have to guess why a specific byte or literal was chosen.

--- a/include/logit_cpp/logit/loggers/ILogReader.hpp
+++ b/include/logit_cpp/logit/loggers/ILogReader.hpp
@@ -10,6 +10,9 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#if __cplusplus >= 201703L
+#include <optional>
+#endif
 
 namespace logit {
 
@@ -34,6 +37,28 @@ namespace logit {
         Descending   ///< Newest first.
     };
 
+#if __cplusplus >= 201703L
+    /// \enum LogReadError
+    /// \brief Result status for log read APIs that preserve failure details.
+    enum class LogReadError {
+        None,
+        NotFound,
+        StorageError,
+        DecodeError,
+        UnsupportedVersion,
+        DecompressionError
+    };
+
+    /// \struct LogReadResult
+    /// \brief Value-or-error result returned by detailed log read APIs.
+    template <typename T>
+    struct LogReadResult {
+        std::optional<T> value; ///< Present when the read succeeded with a value.
+        LogReadError error = LogReadError::None; ///< Error status, or None on success.
+        std::string message; ///< Optional diagnostic message for failed reads.
+    };
+#endif
+
     /// \class ILogReader
     /// \brief Optional interface for backends that expose stored records.
     ///
@@ -54,6 +79,18 @@ namespace logit {
             int64_t to_ms,
             std::size_t limit = 0) const = 0;
 
+#if __cplusplus >= 201703L
+        /// \brief Reads records and preserves backend-specific read errors.
+        virtual LogReadResult<std::vector<LogRecordView>> read_range_result(
+            int64_t from_ms,
+            int64_t to_ms,
+            std::size_t limit = 0) const {
+            LogReadResult<std::vector<LogRecordView>> result;
+            result.value = read_range(from_ms, to_ms, limit);
+            return result;
+        }
+#endif
+
         /// \brief Reads the most recent records.
         /// \param limit     Maximum number of records (0 = unlimited).
         /// \param period_ms Time window in milliseconds from now backward (0 = unlimited).
@@ -63,6 +100,18 @@ namespace logit {
             std::size_t limit,
             int64_t period_ms = 0,
             LogReadOrder order = LogReadOrder::Ascending) const = 0;
+
+#if __cplusplus >= 201703L
+        /// \brief Reads recent records and preserves backend-specific read errors.
+        virtual LogReadResult<std::vector<LogRecordView>> read_recent_result(
+            std::size_t limit,
+            int64_t period_ms = 0,
+            LogReadOrder order = LogReadOrder::Ascending) const {
+            LogReadResult<std::vector<LogRecordView>> result;
+            result.value = read_recent(limit, period_ms, order);
+            return result;
+        }
+#endif
     };
 
 } // namespace logit

--- a/include/logit_cpp/logit/loggers/MdbxLogger.hpp
+++ b/include/logit_cpp/logit/loggers/MdbxLogger.hpp
@@ -25,6 +25,41 @@ namespace logit {
         Zstd = 2  ///< Store zstd-compressed payload bytes.
     };
 
+    /// \enum MdbxReadError
+    /// \brief Result status for MDBX read APIs that preserve failure details.
+    enum class MdbxReadError {
+        None,
+        NotFound,
+        StorageError,
+        DecodeError,
+        UnsupportedVersion,
+        DecompressionError
+    };
+
+    /// \struct MdbxReadResult
+    /// \brief Value-or-error result returned by detailed MDBX read APIs.
+    template <typename T>
+    struct MdbxReadResult {
+        std::optional<T> value; ///< Present when the read succeeded with a value.
+        MdbxReadError error = MdbxReadError::None; ///< Error status, or None on success.
+        std::string message; ///< Optional diagnostic message for failed reads.
+    };
+
+    namespace detail {
+        class MdbxReadException : public std::runtime_error {
+        public:
+            MdbxReadException(MdbxReadError error, const std::string& message)
+                : std::runtime_error(message), m_error(error) {}
+
+            MdbxReadError error() const noexcept {
+                return m_error;
+            }
+
+        private:
+            MdbxReadError m_error;
+        };
+    }
+
     /// \class MdbxLogger
     /// \brief Stores formatted logs in MDBX tables with optional async batching.
     class MdbxLogger final : public ILogger, public ILogReader, public ILogSubscriber {
@@ -197,9 +232,19 @@ namespace logit {
                 int64_t from_ms,
                 int64_t to_ms,
                 std::size_t limit = 0) const override {
-            std::vector<LogRecordView> out;
+            auto result = read_range_result(from_ms, to_ms, limit);
+            return result.value ? *result.value : std::vector<LogRecordView>();
+        }
+
+        /// \brief Reads records and preserves storage/decode errors.
+        MdbxReadResult<std::vector<LogRecordView>> read_range_result(
+                int64_t from_ms,
+                int64_t to_ms,
+                std::size_t limit = 0) const {
+            MdbxReadResult<std::vector<LogRecordView>> result;
+            result.value.emplace();
             if (to_ms <= from_ms) {
-                return out;
+                return result;
             }
 
             try {
@@ -210,15 +255,29 @@ namespace logit {
 
                 std::lock_guard<std::mutex> db_lock(m_db_mutex);
                 m_records->for_each_range(from_key, to_key,
-                    [&out, limit](const std::string&, const Record& record) -> bool {
-                        out.push_back(to_view(record));
-                        return limit == 0 || out.size() < limit;
+                    [&result, limit](const std::string&, const Record& record) -> bool {
+                        result.value->push_back(to_view(record));
+                        return limit == 0 || result.value->size() < limit;
                     });
+            } catch (const detail::MdbxReadException& e) {
+                result.value.reset();
+                result.error = e.error();
+                result.message = e.what();
+            } catch (const mdbxc::MdbxException& e) {
+                result.value.reset();
+                result.error = MdbxReadError::StorageError;
+                result.message = e.what();
+            } catch (const std::exception& e) {
+                result.value.reset();
+                result.error = MdbxReadError::DecodeError;
+                result.message = e.what();
             } catch (...) {
-                out.clear();
+                result.value.reset();
+                result.error = MdbxReadError::DecodeError;
+                result.message = "MdbxLogger: unknown read_range error";
             }
 
-            return out;
+            return result;
         }
 
         /// \brief Reads the most recent records.
@@ -230,82 +289,147 @@ namespace logit {
                 std::size_t limit,
                 int64_t period_ms = 0,
                 LogReadOrder order = LogReadOrder::Ascending) const override {
+            auto result = read_recent_result(limit, period_ms, order);
+            return result.value ? *result.value : std::vector<LogRecordView>();
+        }
+
+        /// \brief Reads the most recent records and preserves storage/decode errors.
+        MdbxReadResult<std::vector<LogRecordView>> read_recent_result(
+                std::size_t limit,
+                int64_t period_ms = 0,
+                LogReadOrder order = LogReadOrder::Ascending) const {
             const int64_t now_ms = LOGIT_CURRENT_TIMESTAMP_MS();
             const int64_t from_ms = (period_ms > 0) ? (now_ms - period_ms) : 0;
-            auto records = read_range(from_ms, now_ms + 1, 0);
-            if (limit > 0 && records.size() > limit) {
-                records.erase(
-                    records.begin(),
-                    records.begin() + static_cast<std::ptrdiff_t>(records.size() - limit));
+            auto result = read_range_result(from_ms, now_ms + 1, 0);
+            if (!result.value) {
+                return result;
             }
-            if (order == LogReadOrder::Descending && !records.empty()) {
-                std::reverse(records.begin(), records.end());
+            if (limit > 0 && result.value->size() > limit) {
+                result.value->erase(
+                    result.value->begin(),
+                    result.value->begin() + static_cast<std::ptrdiff_t>(result.value->size() - limit));
             }
-            return records;
+            if (order == LogReadOrder::Descending && !result.value->empty()) {
+                std::reverse(result.value->begin(), result.value->end());
+            }
+            return result;
         }
 
         /// \brief Reads a payload by id.
         std::optional<PayloadView> read_payload(uint64_t payload_id) const {
+            return read_payload_result(payload_id).value;
+        }
+
+        /// \brief Reads a payload by id and preserves storage/decode errors.
+        MdbxReadResult<PayloadView> read_payload_result(uint64_t payload_id) const {
+            MdbxReadResult<PayloadView> result;
             if (payload_id == 0) {
-                return std::nullopt;
+                result.error = MdbxReadError::NotFound;
+                result.message = "MdbxLogger: payload id is zero";
+                return result;
             }
 
             try {
                 std::lock_guard<std::mutex> db_lock(m_db_mutex);
 #if __cplusplus >= 201703L
                 auto value = m_payloads->find(payload_id);
-                if (!value) return std::nullopt;
-                return to_view(*value);
+                if (!value) return make_not_found_result<PayloadView>("MdbxLogger: payload not found");
+                result.value = to_view(*value);
 #else
                 std::pair<bool, Payload> value = m_payloads->find(payload_id);
-                if (!value.first) return std::nullopt;
-                return to_view(value.second);
+                if (!value.first) return make_not_found_result<PayloadView>("MdbxLogger: payload not found");
+                result.value = to_view(value.second);
 #endif
+            } catch (const detail::MdbxReadException& e) {
+                result.error = e.error();
+                result.message = e.what();
+            } catch (const mdbxc::MdbxException& e) {
+                result.error = MdbxReadError::StorageError;
+                result.message = e.what();
+            } catch (const std::exception& e) {
+                result.error = MdbxReadError::DecodeError;
+                result.message = e.what();
             } catch (...) {
-                return std::nullopt;
+                result.error = MdbxReadError::DecodeError;
+                result.message = "MdbxLogger: unknown payload read error";
             }
+            return result;
         }
 
         /// \brief Reads and decompresses payload data by id.
         /// \return Original (decompressed) payload string, or std::nullopt if not found or decompression fails.
         std::optional<std::string> read_payload_data(uint64_t payload_id) const {
-            auto view = read_payload(payload_id);
-            if (!view) {
-                return std::nullopt;
+            return read_payload_data_result(payload_id).value;
+        }
+
+        /// \brief Reads and decompresses payload data while preserving failure details.
+        MdbxReadResult<std::string> read_payload_data_result(uint64_t payload_id) const {
+            MdbxReadResult<std::string> result;
+            auto view = read_payload_result(payload_id);
+            if (!view.value) {
+                result.error = view.error;
+                result.message = view.message;
+                return result;
             }
-            if (view->compression == MdbxPayloadCompression::None) {
-                return view->data;
+            if (view.value->compression == MdbxPayloadCompression::None) {
+                result.value = view.value->data;
+                return result;
             }
             std::string output;
             bool ok = false;
-            if (view->compression == MdbxPayloadCompression::Gzip) {
-                ok = detail::decompress_string_gzip(view->data, output);
-            } else if (view->compression == MdbxPayloadCompression::Zstd) {
-                ok = detail::decompress_string_zstd(view->data, output);
+            if (view.value->compression == MdbxPayloadCompression::Gzip) {
+                ok = detail::decompress_string_gzip(view.value->data, output);
+            } else if (view.value->compression == MdbxPayloadCompression::Zstd) {
+                ok = detail::decompress_string_zstd(view.value->data, output);
             }
-            return ok ? std::optional<std::string>(std::move(output)) : std::nullopt;
+            if (ok) {
+                result.value = std::move(output);
+            } else {
+                result.error = MdbxReadError::DecompressionError;
+                result.message = "MdbxLogger: failed to decompress payload data";
+            }
+            return result;
         }
 
         /// \brief Reads session metadata by id.
         std::optional<SessionView> read_session(uint64_t session_id) const {
+            return read_session_result(session_id).value;
+        }
+
+        /// \brief Reads session metadata by id and preserves storage/decode errors.
+        MdbxReadResult<SessionView> read_session_result(uint64_t session_id) const {
+            MdbxReadResult<SessionView> result;
             if (session_id == 0) {
-                return std::nullopt;
+                result.error = MdbxReadError::NotFound;
+                result.message = "MdbxLogger: session id is zero";
+                return result;
             }
 
             try {
                 std::lock_guard<std::mutex> db_lock(m_db_mutex);
 #if __cplusplus >= 201703L
                 auto value = m_sessions->find(session_id);
-                if (!value) return std::nullopt;
-                return to_view(*value);
+                if (!value) return make_not_found_result<SessionView>("MdbxLogger: session not found");
+                result.value = to_view(*value);
 #else
                 std::pair<bool, Session> value = m_sessions->find(session_id);
-                if (!value.first) return std::nullopt;
-                return to_view(value.second);
+                if (!value.first) return make_not_found_result<SessionView>("MdbxLogger: session not found");
+                result.value = to_view(value.second);
 #endif
+            } catch (const detail::MdbxReadException& e) {
+                result.error = e.error();
+                result.message = e.what();
+            } catch (const mdbxc::MdbxException& e) {
+                result.error = MdbxReadError::StorageError;
+                result.message = e.what();
+            } catch (const std::exception& e) {
+                result.error = MdbxReadError::DecodeError;
+                result.message = e.what();
             } catch (...) {
-                return std::nullopt;
+                result.error = MdbxReadError::DecodeError;
+                result.message = "MdbxLogger: unknown session read error";
             }
+            return result;
         }
 
         std::string get_string_param(const LoggerParam& param) const override {
@@ -455,6 +579,14 @@ namespace logit {
         std::unordered_map<uint64_t, Callback> m_callbacks;
         std::atomic<uint64_t> m_next_callback_id{1};
 
+        template <typename T>
+        static MdbxReadResult<T> make_not_found_result(const std::string& message) {
+            MdbxReadResult<T> result;
+            result.error = MdbxReadError::NotFound;
+            result.message = message;
+            return result;
+        }
+
         void notify_callbacks(const std::vector<LogRecordView>& views) const {
             std::vector<Callback> callbacks_copy;
             {
@@ -528,7 +660,9 @@ namespace logit {
             detail::MdbxByteReader in(data, size);
             const uint32_t version = in.read_u32();
             if (version != 1) {
-                throw std::runtime_error("MdbxLogger: unsupported session value version");
+                throw detail::MdbxReadException(
+                    MdbxReadError::UnsupportedVersion,
+                    "MdbxLogger: unsupported session value version");
             }
             Session s;
             s.app_name = in.read_string();
@@ -559,7 +693,9 @@ namespace logit {
             detail::MdbxByteReader in(data, size);
             const uint32_t version = in.read_u32();
             if (version != 1) {
-                throw std::runtime_error("MdbxLogger: unsupported record value version");
+                throw detail::MdbxReadException(
+                    MdbxReadError::UnsupportedVersion,
+                    "MdbxLogger: unsupported record value version");
             }
             Record r;
             r.session_id = in.read_u64();
@@ -588,13 +724,17 @@ namespace logit {
             detail::MdbxByteReader in(data, size);
             const uint32_t version = in.read_u32();
             if (version != 1) {
-                throw std::runtime_error("MdbxLogger: unsupported payload value version");
+                throw detail::MdbxReadException(
+                    MdbxReadError::UnsupportedVersion,
+                    "MdbxLogger: unsupported payload value version");
             }
             Payload p;
             p.payload_id = in.read_u64();
             const uint8_t compression = in.read_u8();
             if (compression > static_cast<uint8_t>(MdbxPayloadCompression::Zstd)) {
-                throw std::runtime_error("MdbxLogger: unsupported payload compression");
+                throw detail::MdbxReadException(
+                    MdbxReadError::DecodeError,
+                    "MdbxLogger: unsupported payload compression");
             }
             p.compression = static_cast<MdbxPayloadCompression>(compression);
             p.data = in.read_string();

--- a/include/logit_cpp/logit/loggers/MdbxLogger.hpp
+++ b/include/logit_cpp/logit/loggers/MdbxLogger.hpp
@@ -25,38 +25,18 @@ namespace logit {
         Zstd = 2  ///< Store zstd-compressed payload bytes.
     };
 
-    /// \enum MdbxReadError
-    /// \brief Result status for MDBX read APIs that preserve failure details.
-    enum class MdbxReadError {
-        None,
-        NotFound,
-        StorageError,
-        DecodeError,
-        UnsupportedVersion,
-        DecompressionError
-    };
-
-    /// \struct MdbxReadResult
-    /// \brief Value-or-error result returned by detailed MDBX read APIs.
-    template <typename T>
-    struct MdbxReadResult {
-        std::optional<T> value; ///< Present when the read succeeded with a value.
-        MdbxReadError error = MdbxReadError::None; ///< Error status, or None on success.
-        std::string message; ///< Optional diagnostic message for failed reads.
-    };
-
     namespace detail {
         class MdbxReadException : public std::runtime_error {
         public:
-            MdbxReadException(MdbxReadError error, const std::string& message)
+            MdbxReadException(LogReadError error, const std::string& message)
                 : std::runtime_error(message), m_error(error) {}
 
-            MdbxReadError error() const noexcept {
+            LogReadError error() const noexcept {
                 return m_error;
             }
 
         private:
-            MdbxReadError m_error;
+            LogReadError m_error;
         };
     }
 
@@ -237,11 +217,11 @@ namespace logit {
         }
 
         /// \brief Reads records and preserves storage/decode errors.
-        MdbxReadResult<std::vector<LogRecordView>> read_range_result(
+        LogReadResult<std::vector<LogRecordView>> read_range_result(
                 int64_t from_ms,
                 int64_t to_ms,
                 std::size_t limit = 0) const {
-            MdbxReadResult<std::vector<LogRecordView>> result;
+            LogReadResult<std::vector<LogRecordView>> result;
             result.value.emplace();
             if (to_ms <= from_ms) {
                 return result;
@@ -265,15 +245,15 @@ namespace logit {
                 result.message = e.what();
             } catch (const mdbxc::MdbxException& e) {
                 result.value.reset();
-                result.error = MdbxReadError::StorageError;
+                result.error = LogReadError::StorageError;
                 result.message = e.what();
             } catch (const std::exception& e) {
                 result.value.reset();
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = e.what();
             } catch (...) {
                 result.value.reset();
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = "MdbxLogger: unknown read_range error";
             }
 
@@ -294,7 +274,7 @@ namespace logit {
         }
 
         /// \brief Reads the most recent records and preserves storage/decode errors.
-        MdbxReadResult<std::vector<LogRecordView>> read_recent_result(
+        LogReadResult<std::vector<LogRecordView>> read_recent_result(
                 std::size_t limit,
                 int64_t period_ms = 0,
                 LogReadOrder order = LogReadOrder::Ascending) const {
@@ -321,10 +301,10 @@ namespace logit {
         }
 
         /// \brief Reads a payload by id and preserves storage/decode errors.
-        MdbxReadResult<PayloadView> read_payload_result(uint64_t payload_id) const {
-            MdbxReadResult<PayloadView> result;
+        LogReadResult<PayloadView> read_payload_result(uint64_t payload_id) const {
+            LogReadResult<PayloadView> result;
             if (payload_id == 0) {
-                result.error = MdbxReadError::NotFound;
+                result.error = LogReadError::NotFound;
                 result.message = "MdbxLogger: payload id is zero";
                 return result;
             }
@@ -344,13 +324,13 @@ namespace logit {
                 result.error = e.error();
                 result.message = e.what();
             } catch (const mdbxc::MdbxException& e) {
-                result.error = MdbxReadError::StorageError;
+                result.error = LogReadError::StorageError;
                 result.message = e.what();
             } catch (const std::exception& e) {
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = e.what();
             } catch (...) {
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = "MdbxLogger: unknown payload read error";
             }
             return result;
@@ -363,8 +343,8 @@ namespace logit {
         }
 
         /// \brief Reads and decompresses payload data while preserving failure details.
-        MdbxReadResult<std::string> read_payload_data_result(uint64_t payload_id) const {
-            MdbxReadResult<std::string> result;
+        LogReadResult<std::string> read_payload_data_result(uint64_t payload_id) const {
+            LogReadResult<std::string> result;
             auto view = read_payload_result(payload_id);
             if (!view.value) {
                 result.error = view.error;
@@ -385,7 +365,7 @@ namespace logit {
             if (ok) {
                 result.value = std::move(output);
             } else {
-                result.error = MdbxReadError::DecompressionError;
+                result.error = LogReadError::DecompressionError;
                 result.message = "MdbxLogger: failed to decompress payload data";
             }
             return result;
@@ -397,10 +377,10 @@ namespace logit {
         }
 
         /// \brief Reads session metadata by id and preserves storage/decode errors.
-        MdbxReadResult<SessionView> read_session_result(uint64_t session_id) const {
-            MdbxReadResult<SessionView> result;
+        LogReadResult<SessionView> read_session_result(uint64_t session_id) const {
+            LogReadResult<SessionView> result;
             if (session_id == 0) {
-                result.error = MdbxReadError::NotFound;
+                result.error = LogReadError::NotFound;
                 result.message = "MdbxLogger: session id is zero";
                 return result;
             }
@@ -420,13 +400,13 @@ namespace logit {
                 result.error = e.error();
                 result.message = e.what();
             } catch (const mdbxc::MdbxException& e) {
-                result.error = MdbxReadError::StorageError;
+                result.error = LogReadError::StorageError;
                 result.message = e.what();
             } catch (const std::exception& e) {
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = e.what();
             } catch (...) {
-                result.error = MdbxReadError::DecodeError;
+                result.error = LogReadError::DecodeError;
                 result.message = "MdbxLogger: unknown session read error";
             }
             return result;
@@ -580,9 +560,9 @@ namespace logit {
         std::atomic<uint64_t> m_next_callback_id{1};
 
         template <typename T>
-        static MdbxReadResult<T> make_not_found_result(const std::string& message) {
-            MdbxReadResult<T> result;
-            result.error = MdbxReadError::NotFound;
+        static LogReadResult<T> make_not_found_result(const std::string& message) {
+            LogReadResult<T> result;
+            result.error = LogReadError::NotFound;
             result.message = message;
             return result;
         }
@@ -661,7 +641,7 @@ namespace logit {
             const uint32_t version = in.read_u32();
             if (version != 1) {
                 throw detail::MdbxReadException(
-                    MdbxReadError::UnsupportedVersion,
+                    LogReadError::UnsupportedVersion,
                     "MdbxLogger: unsupported session value version");
             }
             Session s;
@@ -694,7 +674,7 @@ namespace logit {
             const uint32_t version = in.read_u32();
             if (version != 1) {
                 throw detail::MdbxReadException(
-                    MdbxReadError::UnsupportedVersion,
+                    LogReadError::UnsupportedVersion,
                     "MdbxLogger: unsupported record value version");
             }
             Record r;
@@ -725,7 +705,7 @@ namespace logit {
             const uint32_t version = in.read_u32();
             if (version != 1) {
                 throw detail::MdbxReadException(
-                    MdbxReadError::UnsupportedVersion,
+                    LogReadError::UnsupportedVersion,
                     "MdbxLogger: unsupported payload value version");
             }
             Payload p;
@@ -733,7 +713,7 @@ namespace logit {
             const uint8_t compression = in.read_u8();
             if (compression > static_cast<uint8_t>(MdbxPayloadCompression::Zstd)) {
                 throw detail::MdbxReadException(
-                    MdbxReadError::DecodeError,
+                    LogReadError::DecodeError,
                     "MdbxLogger: unsupported payload compression");
             }
             p.compression = static_cast<MdbxPayloadCompression>(compression);

--- a/include/logit_cpp/logit/loggers/MdbxLogger.hpp
+++ b/include/logit_cpp/logit/loggers/MdbxLogger.hpp
@@ -220,7 +220,7 @@ namespace logit {
         LogReadResult<std::vector<LogRecordView>> read_range_result(
                 int64_t from_ms,
                 int64_t to_ms,
-                std::size_t limit = 0) const {
+                std::size_t limit = 0) const override {
             LogReadResult<std::vector<LogRecordView>> result;
             result.value.emplace();
             if (to_ms <= from_ms) {
@@ -277,7 +277,7 @@ namespace logit {
         LogReadResult<std::vector<LogRecordView>> read_recent_result(
                 std::size_t limit,
                 int64_t period_ms = 0,
-                LogReadOrder order = LogReadOrder::Ascending) const {
+                LogReadOrder order = LogReadOrder::Ascending) const override {
             const int64_t now_ms = LOGIT_CURRENT_TIMESTAMP_MS();
             const int64_t from_ms = (period_ms > 0) ? (now_ms - period_ms) : 0;
             auto result = read_range_result(from_ms, now_ms + 1, 0);

--- a/include/logit_cpp/logit/loggers/MemoryLogger.hpp
+++ b/include/logit_cpp/logit/loggers/MemoryLogger.hpp
@@ -148,6 +148,10 @@ namespace logit {
                 int64_t from_ms,
                 int64_t to_ms,
                 std::size_t limit = 0) const override {
+#if __cplusplus >= 201703L
+            auto result = read_range_result(from_ms, to_ms, limit);
+            return result.value ? *result.value : std::vector<LogRecordView>();
+#else
             std::vector<LogRecordView> out;
             if (to_ms <= from_ms) {
                 return out;
@@ -165,13 +169,45 @@ namespace logit {
                 }
             }
             return out;
+#endif
         }
+
+#if __cplusplus >= 201703L
+        /// \brief Reads records and reports MemoryLogger read status.
+        LogReadResult<std::vector<LogRecordView>> read_range_result(
+                int64_t from_ms,
+                int64_t to_ms,
+                std::size_t limit = 0) const override {
+            LogReadResult<std::vector<LogRecordView>> result;
+            result.value.emplace();
+            if (to_ms <= from_ms) {
+                return result;
+            }
+
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_evict_expired_locked(LOGIT_CURRENT_TIMESTAMP_MS());
+
+            for (const auto& entry : m_entries) {
+                if (entry.timestamp_ms >= from_ms && entry.timestamp_ms < to_ms) {
+                    result.value->push_back(to_view(entry));
+                    if (limit > 0 && result.value->size() >= limit) {
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+#endif
 
         /// \brief Reads the most recent records.
         std::vector<LogRecordView> read_recent(
                 std::size_t limit,
                 int64_t period_ms = 0,
                 LogReadOrder order = LogReadOrder::Ascending) const override {
+#if __cplusplus >= 201703L
+            auto result = read_recent_result(limit, period_ms, order);
+            return result.value ? *result.value : std::vector<LogRecordView>();
+#else
             std::vector<LogRecordView> out;
             std::lock_guard<std::mutex> lock(m_mutex);
             m_evict_expired_locked(LOGIT_CURRENT_TIMESTAMP_MS());
@@ -192,7 +228,38 @@ namespace logit {
                 std::reverse(out.begin(), out.end());
             }
             return out;
+#endif
         }
+
+#if __cplusplus >= 201703L
+        /// \brief Reads recent records and reports MemoryLogger read status.
+        LogReadResult<std::vector<LogRecordView>> read_recent_result(
+                std::size_t limit,
+                int64_t period_ms = 0,
+                LogReadOrder order = LogReadOrder::Ascending) const override {
+            LogReadResult<std::vector<LogRecordView>> result;
+            result.value.emplace();
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_evict_expired_locked(LOGIT_CURRENT_TIMESTAMP_MS());
+
+            const int64_t now_ms = LOGIT_CURRENT_TIMESTAMP_MS();
+            const int64_t from_ms = (period_ms > 0) ? (now_ms - period_ms) : 0;
+
+            for (auto it = m_entries.rbegin(); it != m_entries.rend(); ++it) {
+                if (period_ms <= 0 || it->timestamp_ms >= from_ms) {
+                    result.value->push_back(to_view(*it));
+                    if (limit > 0 && result.value->size() >= limit) {
+                        break;
+                    }
+                }
+            }
+
+            if (order == LogReadOrder::Ascending) {
+                std::reverse(result.value->begin(), result.value->end());
+            }
+            return result;
+        }
+#endif
 
     private:
         static LogRecordView to_view(const BufferedLogEntry& e) {

--- a/tests/mdbx_logger_test.cpp
+++ b/tests/mdbx_logger_test.cpp
@@ -79,6 +79,71 @@ logit::LogRecord make_record(logit::LogLevel level, int64_t timestamp_ms, int li
         false);
 }
 
+mdbxc::Config make_raw_db_config(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 4;
+    config.no_subdir = true;
+    config.sync_durable = true;
+    return config;
+}
+
+std::string bytes_to_string(const std::vector<uint8_t>& bytes) {
+    if (bytes.empty()) {
+        return std::string();
+    }
+    return std::string(reinterpret_cast<const char*>(&bytes[0]), bytes.size());
+}
+
+std::string make_unsupported_version_value() {
+    const uint32_t unsupported_schema_version = 2;
+    logit::detail::MdbxByteWriter out;
+    out.write_u32(unsupported_schema_version);
+    return bytes_to_string(out.bytes());
+}
+
+std::string make_payload_value(
+        uint64_t payload_id,
+        logit::MdbxPayloadCompression compression,
+        const std::string& data) {
+    const uint32_t current_schema_version = 1;
+    logit::detail::MdbxByteWriter out;
+    out.write_u32(current_schema_version);
+    out.write_u64(payload_id);
+    out.write_u8(static_cast<uint8_t>(compression));
+    out.write_string(data);
+    return bytes_to_string(out.bytes());
+}
+
+std::string make_payload_with_unknown_compression(uint64_t payload_id) {
+    const uint32_t current_schema_version = 1;
+    const uint8_t unknown_payload_compression = 255;
+    logit::detail::MdbxByteWriter out;
+    out.write_u32(current_schema_version);
+    out.write_u64(payload_id);
+    out.write_u8(unknown_payload_compression);
+    out.write_string("payload");
+    return bytes_to_string(out.bytes());
+}
+
+void write_raw_payload_value(const std::string& path, uint64_t payload_id, const std::string& value) {
+    auto connection = mdbxc::Connection::create(make_raw_db_config(path));
+    mdbxc::KeyValueTable<uint64_t, std::string> payloads(connection, "log_payloads");
+    payloads.insert_or_assign(payload_id, value);
+}
+
+void write_raw_session_value(const std::string& path, uint64_t session_id, const std::string& value) {
+    auto connection = mdbxc::Connection::create(make_raw_db_config(path));
+    mdbxc::KeyValueTable<uint64_t, std::string> sessions(connection, "log_sessions");
+    sessions.insert_or_assign(session_id, value);
+}
+
+void write_raw_record_value(const std::string& path, const std::string& key, const std::string& value) {
+    auto connection = mdbxc::Connection::create(make_raw_db_config(path));
+    mdbxc::KeyValueTable<std::string, std::string> records(connection, "log_records_by_time");
+    records.insert_or_assign(key, value);
+}
+
 void test_sync_range_session_and_sequences() {
     const std::string path = make_db_path("sync");
     cleanup_db(path);
@@ -312,6 +377,105 @@ void test_init_error_callback_and_rethrow() {
     cleanup_path_tree(path);
 }
 
+void test_read_result_not_found() {
+    const std::string path = make_db_path("read_not_found");
+    cleanup_db(path);
+
+    {
+        logit::MdbxLogger::Config config;
+        config.path = path;
+        config.async = false;
+
+        logit::MdbxLogger logger(config);
+        const uint64_t missing_payload_id = 404;
+        const uint64_t missing_session_id = 405;
+
+        auto payload = logger.read_payload_result(missing_payload_id);
+        assert(!payload.value);
+        assert(payload.error == logit::MdbxReadError::NotFound);
+        assert(!payload.message.empty());
+        assert(!logger.read_payload(missing_payload_id));
+
+        auto payload_data = logger.read_payload_data_result(missing_payload_id);
+        assert(!payload_data.value);
+        assert(payload_data.error == logit::MdbxReadError::NotFound);
+        assert(!logger.read_payload_data(missing_payload_id));
+
+        auto session = logger.read_session_result(missing_session_id);
+        assert(!session.value);
+        assert(session.error == logit::MdbxReadError::NotFound);
+        assert(!session.message.empty());
+        assert(!logger.read_session(missing_session_id));
+
+        logger.shutdown();
+    }
+
+    cleanup_db(path);
+}
+
+void test_read_result_decode_errors() {
+    const std::string path = make_db_path("read_decode");
+    cleanup_db(path);
+
+    const uint64_t unsupported_version_payload_id = 501;
+    const uint64_t unknown_compression_payload_id = 502;
+    const uint64_t bad_gzip_payload_id = 503;
+    const uint64_t unsupported_version_session_id = 504;
+    const int64_t corrupt_record_timestamp_ms = 6200;
+    const std::string corrupt_record_key =
+        logit::detail::make_mdbx_record_key(corrupt_record_timestamp_ms, 0);
+
+    write_raw_payload_value(path, unsupported_version_payload_id, make_unsupported_version_value());
+    write_raw_payload_value(path, unknown_compression_payload_id,
+        make_payload_with_unknown_compression(unknown_compression_payload_id));
+    write_raw_payload_value(path, bad_gzip_payload_id,
+        make_payload_value(bad_gzip_payload_id, logit::MdbxPayloadCompression::Gzip, "not-gzip-data"));
+    write_raw_session_value(path, unsupported_version_session_id, make_unsupported_version_value());
+    write_raw_record_value(path, corrupt_record_key, make_unsupported_version_value());
+
+    {
+        logit::MdbxLogger::Config config;
+        config.path = path;
+        config.async = false;
+
+        logit::MdbxLogger logger(config);
+
+        auto unsupported_payload = logger.read_payload_result(unsupported_version_payload_id);
+        assert(!unsupported_payload.value);
+        assert(unsupported_payload.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(!logger.read_payload(unsupported_version_payload_id));
+
+        auto unknown_compression_payload = logger.read_payload_result(unknown_compression_payload_id);
+        assert(!unknown_compression_payload.value);
+        assert(unknown_compression_payload.error == logit::MdbxReadError::DecodeError);
+
+        auto bad_gzip_payload = logger.read_payload_data_result(bad_gzip_payload_id);
+        assert(!bad_gzip_payload.value);
+        assert(bad_gzip_payload.error == logit::MdbxReadError::DecompressionError);
+        assert(!logger.read_payload_data(bad_gzip_payload_id));
+
+        auto unsupported_session = logger.read_session_result(unsupported_version_session_id);
+        assert(!unsupported_session.value);
+        assert(unsupported_session.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(!logger.read_session(unsupported_version_session_id));
+
+        auto corrupt_range = logger.read_range_result(
+            corrupt_record_timestamp_ms,
+            corrupt_record_timestamp_ms + 1);
+        assert(!corrupt_range.value);
+        assert(corrupt_range.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(logger.read_range(corrupt_record_timestamp_ms, corrupt_record_timestamp_ms + 1).empty());
+
+        auto corrupt_recent = logger.read_recent_result(10, LOGIT_CURRENT_TIMESTAMP_MS());
+        assert(!corrupt_recent.value);
+        assert(corrupt_recent.error == logit::MdbxReadError::UnsupportedVersion);
+
+        logger.shutdown();
+    }
+
+    cleanup_db(path);
+}
+
 void test_read_range_empty_and_limits() {
     const std::string path = make_db_path("range");
     cleanup_db(path);
@@ -503,6 +667,8 @@ int main() {
     test_on_error_callback();
     test_nested_parent_directory_created();
     test_init_error_callback_and_rethrow();
+    test_read_result_not_found();
+    test_read_result_decode_errors();
     test_read_range_empty_and_limits();
     test_read_recent();
     test_callback_sync();

--- a/tests/mdbx_logger_test.cpp
+++ b/tests/mdbx_logger_test.cpp
@@ -392,18 +392,18 @@ void test_read_result_not_found() {
 
         auto payload = logger.read_payload_result(missing_payload_id);
         assert(!payload.value);
-        assert(payload.error == logit::MdbxReadError::NotFound);
+        assert(payload.error == logit::LogReadError::NotFound);
         assert(!payload.message.empty());
         assert(!logger.read_payload(missing_payload_id));
 
         auto payload_data = logger.read_payload_data_result(missing_payload_id);
         assert(!payload_data.value);
-        assert(payload_data.error == logit::MdbxReadError::NotFound);
+        assert(payload_data.error == logit::LogReadError::NotFound);
         assert(!logger.read_payload_data(missing_payload_id));
 
         auto session = logger.read_session_result(missing_session_id);
         assert(!session.value);
-        assert(session.error == logit::MdbxReadError::NotFound);
+        assert(session.error == logit::LogReadError::NotFound);
         assert(!session.message.empty());
         assert(!logger.read_session(missing_session_id));
 
@@ -442,33 +442,33 @@ void test_read_result_decode_errors() {
 
         auto unsupported_payload = logger.read_payload_result(unsupported_version_payload_id);
         assert(!unsupported_payload.value);
-        assert(unsupported_payload.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(unsupported_payload.error == logit::LogReadError::UnsupportedVersion);
         assert(!logger.read_payload(unsupported_version_payload_id));
 
         auto unknown_compression_payload = logger.read_payload_result(unknown_compression_payload_id);
         assert(!unknown_compression_payload.value);
-        assert(unknown_compression_payload.error == logit::MdbxReadError::DecodeError);
+        assert(unknown_compression_payload.error == logit::LogReadError::DecodeError);
 
         auto bad_gzip_payload = logger.read_payload_data_result(bad_gzip_payload_id);
         assert(!bad_gzip_payload.value);
-        assert(bad_gzip_payload.error == logit::MdbxReadError::DecompressionError);
+        assert(bad_gzip_payload.error == logit::LogReadError::DecompressionError);
         assert(!logger.read_payload_data(bad_gzip_payload_id));
 
         auto unsupported_session = logger.read_session_result(unsupported_version_session_id);
         assert(!unsupported_session.value);
-        assert(unsupported_session.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(unsupported_session.error == logit::LogReadError::UnsupportedVersion);
         assert(!logger.read_session(unsupported_version_session_id));
 
         auto corrupt_range = logger.read_range_result(
             corrupt_record_timestamp_ms,
             corrupt_record_timestamp_ms + 1);
         assert(!corrupt_range.value);
-        assert(corrupt_range.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(corrupt_range.error == logit::LogReadError::UnsupportedVersion);
         assert(logger.read_range(corrupt_record_timestamp_ms, corrupt_record_timestamp_ms + 1).empty());
 
         auto corrupt_recent = logger.read_recent_result(10, LOGIT_CURRENT_TIMESTAMP_MS());
         assert(!corrupt_recent.value);
-        assert(corrupt_recent.error == logit::MdbxReadError::UnsupportedVersion);
+        assert(corrupt_recent.error == logit::LogReadError::UnsupportedVersion);
 
         logger.shutdown();
     }


### PR DESCRIPTION
## Summary
- add shared LogReadError and LogReadResult<T> in ILogReader for detailed read outcomes
- add result-returning range/recent APIs while keeping existing vector-returning wrappers compatible
- use the shared result type for MdbxLogger payload/session/data-specific read methods
- expose successful result wrappers from MemoryLogger under the C++17 result API
- distinguish not found, storage, decode, unsupported version, and decompression failures in MDBX tests
- include semantic-value guide rules for magic numbers/literals and intention-revealing test data

## Verification
- cmake -S . -B build-mdbx-test -G "MinGW Makefiles" -DLOGIT_CPP_BUILD_TESTS=ON -DLOGIT_WITH_MDBX=ON -DLOGIT_USE_SUBMODULES=ON
- cmake --build build-mdbx-test --target mdbx_logger_test -j2
- ctest --test-dir build-mdbx-test -R mdbx_logger_test --output-on-failure
- git diff --check -- include/logit_cpp/logit/loggers/ILogReader.hpp include/logit_cpp/logit/loggers/MemoryLogger.hpp include/logit_cpp/logit/loggers/MdbxLogger.hpp tests/mdbx_logger_test.cpp guides/cpp_style.md
- cmake -S . -B build-cxx11-check -G "MinGW Makefiles" -DLOGIT_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=11
- cmake --build build-cxx11-check --target memory_logger_backend_test -j2

🤖 Generated with [Claude Code](https://claude.com/claude-code)